### PR TITLE
Fix strict hook blocking gitignore and enhance gen-plan command (v1.3.3)

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -8,7 +8,7 @@
       "name": "humanize",
       "source": "./",
       "description": "Humanize - An iterative development plugin that uses Codex to review Claude's work. Creates a feedback loop where Claude implements plans and Codex independently reviews progress, ensuring quality through continuous refinement.",
-      "version": "1.3.2"
+      "version": "1.3.3"
     }
   ]
 }

--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "humanize",
   "description": "Humanize - An iterative development plugin that uses Codex to review Claude's work. Creates a feedback loop where Claude implements plans and Codex independently reviews progress, ensuring quality through continuous refinement.",
-  "version": "1.3.2",
+  "version": "1.3.3",
   "author": {
     "name": "humania-org"
   },

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # Humanize
 
-**Current Version: 1.3.2**
+**Current Version: 1.3.3**
 
 > Derived from the [GAAC (GitHub-as-a-Context)](https://github.com/SihaoLiu/gaac) project.
 

--- a/commands/gen-plan.md
+++ b/commands/gen-plan.md
@@ -23,6 +23,7 @@ This command transforms a user's draft document into a well-structured implement
 3. **Draft Analysis**: Analyze draft for clarity, consistency, completeness, and functionality
 4. **Issue Resolution**: Engage user to clarify any issues found
 5. **Plan Generation**: Generate the structured plan.md
+6. **Write and Complete**: Write output file and report results
 
 ---
 
@@ -48,6 +49,8 @@ Execute the validation script with the provided arguments:
 ## Phase 2: Relevance Check
 
 After IO validation passes, check if the draft is relevant to this repository.
+
+> **Note**: Do not spend too much time on this check. As long as the draft is not completely unrelated to the current project - not like the difference between ship design and cake recipes - it passes.
 
 1. Read the input draft file to get its content
 2. Use the Task tool to invoke the `humanize:draft-relevance-checker` agent (haiku model):
@@ -106,6 +109,8 @@ Use the Task tool with `subagent_type: "Explore"` to investigate:
 
 ## Phase 4: Issue Resolution
 
+### Step 1: Resolve Analysis Issues
+
 If any issues are found during analysis, use AskUserQuestion to clarify with the user.
 
 For each issue category that has problems, present:
@@ -114,6 +119,20 @@ For each issue category that has problems, present:
 - Options for resolution (if applicable)
 
 Continue this dialogue until all significant issues are resolved or acknowledged by the user.
+
+### Step 2: Confirm Quantitative Metrics
+
+After all analysis issues are resolved, check the draft for any quantitative metrics or numeric thresholds, such as:
+- Performance targets: "less than 15GB/s", "under 100ms latency"
+- Size constraints: "below 300KB", "maximum 1MB"
+- Count limits: "more than 10 files", "at least 5 retries"
+- Percentage goals: "95% coverage", "reduce by 50%"
+
+For each quantitative metric found, use AskUserQuestion to explicitly confirm with the user:
+- Is this a **hard requirement** that must be achieved for the implementation to be considered successful?
+- Or is this describing an **optimization trend/direction** where improvement toward the target is acceptable even if the exact number is not reached?
+
+Document the user's answer for each metric, as this distinction significantly affects how acceptance criteria should be written in the plan.
 
 ---
 

--- a/hooks/lib/loop-common.sh
+++ b/hooks/lib/loop-common.sh
@@ -764,7 +764,17 @@ These commands are blocked when .humanize exists:
     git add -A             # adds all including .humanize
     git add --all          # adds all including .humanize
     git add .              # may include .humanize if not gitignored
-    git add -f .           # force bypasses gitignore"
+    git add -f .           # force bypasses gitignore
+
+## Adding .humanize to .gitignore
+
+If you need to add \`.humanize*\` to \`.gitignore\`, follow these steps:
+
+1. Edit \`.gitignore\` to append \`.humanize*\`
+2. Run: \`git add .gitignore\`
+3. Run: \`git commit -m \"Add humanize local folder into gitignore\"\`
+
+IMPORTANT: The commit message must NOT contain the literal string \".humanize\" to avoid triggering this protection."
 
     load_and_render_safe "$TEMPLATE_DIR" "block/git-add-humanize.md" "$fallback"
 }

--- a/prompt-template/block/git-add-humanize.md
+++ b/prompt-template/block/git-add-humanize.md
@@ -22,3 +22,13 @@ These commands are blocked when .humanize exists:
     git add --all          # adds all including .humanize
     git add .              # may include .humanize if not gitignored
     git add -f .           # force bypasses gitignore
+
+## Adding .humanize to .gitignore
+
+If you need to add `.humanize*` to `.gitignore`, follow these steps:
+
+1. Edit `.gitignore` to append `.humanize*`
+2. Run: `git add .gitignore`
+3. Run: `git commit -m "Add humanize local folder into gitignore"`
+
+IMPORTANT: The commit message must NOT contain the literal string ".humanize" to avoid triggering this protection.


### PR DESCRIPTION
## Summary
- Add guidance in git-add-humanize block message for legitimately adding .humanize to .gitignore (workaround: use commit message without literal ".humanize" string)
- Enhance gen-plan Phase 2: Add note to not over-check relevance (as long as draft is not completely unrelated like ship design vs cake recipes, it passes)
- Enhance gen-plan Phase 4: Add Step 2 to confirm quantitative metrics as hard requirements vs optimization trends
- Fix Workflow Overview to include all 6 phases