### PR TITLE
Add HUMANIZE_CODEX_BYPASS_SANDBOX environment variable support (v1.6.4)

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -8,7 +8,7 @@
       "name": "humanize",
       "source": "./",
       "description": "Humanize - An iterative development plugin that uses Codex to review Claude's work. Creates a feedback loop where Claude implements plans and Codex independently reviews progress, ensuring quality through continuous refinement.",
-      "version": "1.6.3"
+      "version": "1.6.4"
     }
   ]
 }

--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "humanize",
   "description": "Humanize - An iterative development plugin that uses Codex to review Claude's work. Creates a feedback loop where Claude implements plans and Codex independently reviews progress, ensuring quality through continuous refinement.",
-  "version": "1.6.3",
+  "version": "1.6.4",
   "author": {
     "name": "humania-org"
   },

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # Humanize
 
-**Current Version: 1.6.3**
+**Current Version: 1.6.4**
 
 > Derived from the [GAAC (GitHub-as-a-Context)](https://github.com/SihaoLiu/gaac) project.
 
@@ -52,6 +52,45 @@ claude --plugin-dir /path/to/humanize
 ### Prerequisites
 
 - `codex` - OpenAI Codex CLI (for review). Check with `codex --version`.
+
+### Environment Variables
+
+Humanize supports the following environment variables for advanced configuration:
+
+#### HUMANIZE_CODEX_BYPASS_SANDBOX
+
+**WARNING: This is a dangerous option that disables security protections. Use only if you understand the implications.**
+
+- **Purpose**: Controls whether Codex runs with sandbox protection
+- **Default**: Not set (uses `--full-auto` with sandbox protection)
+- **Values**:
+  - `true` or `1`: Bypasses Codex sandbox and approvals (uses `--dangerously-bypass-approvals-and-sandbox`)
+  - Any other value or unset: Uses safe mode with sandbox
+
+**When to use this**:
+- Linux servers without landlock kernel support (where Codex sandbox fails)
+- Automated CI/CD pipelines in trusted environments
+- Development environments where you have full control
+
+**When NOT to use this**:
+- Public or shared development servers
+- When reviewing untrusted code or pull requests
+- Production systems
+- Any environment where unauthorized system access could cause damage
+
+**Security implications**:
+- Codex will have unrestricted access to your filesystem
+- Codex can execute arbitrary commands without approval prompts
+- Review all code changes carefully when using this mode
+
+**Usage example**:
+```bash
+# Export before starting Claude Code
+export HUMANIZE_CODEX_BYPASS_SANDBOX=true
+
+# Or set for a single session
+HUMANIZE_CODEX_BYPASS_SANDBOX=true claude --plugin-dir /path/to/humanize
+```
 
 ## Usage
 

--- a/hooks/loop-codex-stop-hook.sh
+++ b/hooks/loop-codex-stop-hook.sh
@@ -889,12 +889,21 @@ mkdir -p "$CACHE_DIR"
 # Note: portable-timeout.sh already sourced at line 52
 
 # Build Codex command arguments for codex exec
-# codex exec uses: -m MODEL, --full-auto, -C DIR, -c key=value
+# codex exec uses: -m MODEL, --full-auto (or --dangerously-bypass-approvals-and-sandbox), -C DIR, -c key=value
 CODEX_EXEC_ARGS=("-m" "$CODEX_MODEL")
 if [[ -n "$CODEX_EFFORT" ]]; then
     CODEX_EXEC_ARGS+=("-c" "model_reasoning_effort=${CODEX_EFFORT}")
 fi
-CODEX_EXEC_ARGS+=("--full-auto" "-C" "$PROJECT_ROOT")
+
+# Determine automation flag based on environment variable
+# Default: Use --full-auto (safe mode with sandbox)
+# If HUMANIZE_CODEX_BYPASS_SANDBOX is "true" or "1": Use --dangerously-bypass-approvals-and-sandbox
+CODEX_AUTO_FLAG="--full-auto"
+if [[ "${HUMANIZE_CODEX_BYPASS_SANDBOX:-}" == "true" ]] || [[ "${HUMANIZE_CODEX_BYPASS_SANDBOX:-}" == "1" ]]; then
+    CODEX_AUTO_FLAG="--dangerously-bypass-approvals-and-sandbox"
+fi
+
+CODEX_EXEC_ARGS+=("$CODEX_AUTO_FLAG" "-C" "$PROJECT_ROOT")
 
 # Build Codex command arguments for codex review
 # codex review uses different format: -c model=xxx -c review_model=xxx -c model_reasoning_effort=xxx

--- a/hooks/pr-loop-stop-hook.sh
+++ b/hooks/pr-loop-stop-hook.sh
@@ -1324,7 +1324,16 @@ CODEX_ARGS=("-m" "$PR_CODEX_MODEL")
 if [[ -n "$PR_CODEX_EFFORT" ]]; then
     CODEX_ARGS+=("-c" "model_reasoning_effort=${PR_CODEX_EFFORT}")
 fi
-CODEX_ARGS+=("--full-auto" "-C" "$PROJECT_ROOT")
+
+# Determine automation flag based on environment variable
+# Default: Use --full-auto (safe mode with sandbox)
+# If HUMANIZE_CODEX_BYPASS_SANDBOX is "true" or "1": Use --dangerously-bypass-approvals-and-sandbox
+CODEX_AUTO_FLAG="--full-auto"
+if [[ "${HUMANIZE_CODEX_BYPASS_SANDBOX:-}" == "true" ]] || [[ "${HUMANIZE_CODEX_BYPASS_SANDBOX:-}" == "1" ]]; then
+    CODEX_AUTO_FLAG="--dangerously-bypass-approvals-and-sandbox"
+fi
+
+CODEX_ARGS+=("$CODEX_AUTO_FLAG" "-C" "$PROJECT_ROOT")
 
 CODEX_PROMPT_CONTENT=$(cat "$CODEX_PROMPT_FILE")
 CODEX_EXIT_CODE=0


### PR DESCRIPTION
## Summary

- Add support for `HUMANIZE_CODEX_BYPASS_SANDBOX` environment variable to bypass Codex sandbox on Linux servers without landlock kernel support
- Safe by default: requires explicit opt-in with `true` or `1` value
- Applies to both RLCR loop and PR loop stop hooks
- Add comprehensive security warnings in README
- Version bump: 1.6.3 -> 1.6.4

## Problem

Some Linux servers do not have landlock enabled in their kernel, which causes Codex's sandbox mechanism to fail with 100% rejection rate. This makes the Humanize plugin unusable on such servers.

## Solution

Add `HUMANIZE_CODEX_BYPASS_SANDBOX` environment variable that allows users to explicitly opt-in to bypass the sandbox:

- **Default behavior**: Uses `--full-auto` (safe mode with sandbox protection)
- **When set to `true` or `1`**: Uses `--dangerously-bypass-approvals-and-sandbox`
- **Any other value**: Falls back to safe mode

## Implementation Details

**Modified files:**
- `hooks/loop-codex-stop-hook.sh` - Add env var check before building Codex arguments
- `hooks/pr-loop-stop-hook.sh` - Add env var check before building Codex arguments
- `README.md` - Add "Environment Variables" section with security warnings
- `.claude-plugin/plugin.json` - Version bump to 1.6.4
- `.claude-plugin/marketplace.json` - Version bump to 1.6.4

**Design principles:**
- Safe by default: Only exact values "true" or "1" activate bypass
- No unnecessary output: No echo statements to avoid token waste
- Consistent implementation across both hook files

## Test plan

- [ ] Test default behavior: Verify `--full-auto` is used when env var is not set
- [ ] Test bypass mode with "true": Verify `--dangerously-bypass-approvals-and-sandbox` is used
- [ ] Test bypass mode with "1": Verify same behavior as "true"
- [ ] Test invalid values: Verify falls back to `--full-auto`
- [ ] Test both RLCR and PR loops behave consistently
- [ ] Verify no regression in existing functionality