### PR TITLE
Add methodology analysis phase for RLCR loop exit

### DIFF
--- a/commands/cancel-rlcr-loop.md
+++ b/commands/cancel-rlcr-loop.md
@@ -17,6 +17,7 @@ To cancel the active loop:
 2. Check the first line of output:
    - **NO_LOOP** or **NO_ACTIVE_LOOP**: Say "No active RLCR loop found."
    - **CANCELLED**: Report the cancellation message from the output
+   - **CANCELLED_METHODOLOGY_ANALYSIS**: Report the cancellation message from the output
    - **CANCELLED_FINALIZE**: Report the cancellation message from the output
    - **FINALIZE_NEEDS_CONFIRM**: The loop is in Finalize Phase. Continue to step 3
 
@@ -33,6 +34,6 @@ To cancel the active loop:
    - **If user chooses "No, let it finish"**:
      - Report: "Understood. The Finalize Phase will continue. Once complete, the loop will end normally."
 
-**Key principle**: The script handles all cancellation logic. A loop is active if `state.md` (normal loop) or `finalize-state.md` (Finalize Phase) exists in the newest loop directory.
+**Key principle**: The script handles all cancellation logic. A loop is active if `state.md` (normal loop), `methodology-analysis-state.md` (Methodology Analysis Phase), or `finalize-state.md` (Finalize Phase) exists in the newest loop directory.
 
 The loop directory with summaries, review results, and state information will be preserved for reference.

--- a/commands/start-rlcr-loop.md
+++ b/commands/start-rlcr-loop.md
@@ -1,6 +1,6 @@
 ---
 description: "Start iterative loop with Codex review"
-argument-hint: "[path/to/plan.md | --plan-file path/to/plan.md] [--max N] [--codex-model MODEL:EFFORT] [--codex-timeout SECONDS] [--track-plan-file] [--push-every-round] [--base-branch BRANCH] [--full-review-round N] [--skip-impl] [--claude-answer-codex] [--agent-teams]"
+argument-hint: "[path/to/plan.md | --plan-file path/to/plan.md] [--max N] [--codex-model MODEL:EFFORT] [--codex-timeout SECONDS] [--track-plan-file] [--push-every-round] [--base-branch BRANCH] [--full-review-round N] [--skip-impl] [--claude-answer-codex] [--agent-teams] [--privacy]"
 allowed-tools:
   - "Bash(${CLAUDE_PLUGIN_ROOT}/scripts/setup-rlcr-loop.sh:*)"
   - "Read"

--- a/hooks/lib/loop-common.sh
+++ b/hooks/lib/loop-common.sh
@@ -339,6 +339,12 @@ find_active_loop() {
 # This ensures spawned agents (which have different session_ids) always bind to
 # the correct originating loop during methodology analysis.
 #
+# Limitation: If two loops are simultaneously in methodology analysis, this
+# returns the newest one. The older session's spawned agents would bind to the
+# wrong loop. This is accepted because concurrent methodology analyses are
+# extremely unlikely (the phase is short-lived and requires two active RLCR
+# sessions to overlap at this specific point).
+#
 # Args:
 #   $1 - loop_base_dir: path to .humanize/rlcr
 #

--- a/hooks/lib/loop-common.sh
+++ b/hooks/lib/loop-common.sh
@@ -332,43 +332,6 @@ find_active_loop() {
     echo ""
 }
 
-# Find any active loop directory currently in methodology analysis phase.
-# Unlike find_active_loop() which returns the newest active loop (possibly the
-# wrong one when multiple concurrent sessions exist), this function specifically
-# searches for a loop with methodology-analysis-state.md present.
-# This ensures spawned agents (which have different session_ids) always bind to
-# the correct originating loop during methodology analysis.
-#
-# Limitation: If two loops are simultaneously in methodology analysis, this
-# returns the newest one. The older session's spawned agents would bind to the
-# wrong loop. This is accepted because concurrent methodology analyses are
-# extremely unlikely (the phase is short-lived and requires two active RLCR
-# sessions to overlap at this specific point).
-#
-# Args:
-#   $1 - loop_base_dir: path to .humanize/rlcr
-#
-# Outputs the directory path to stdout, or empty string if none found
-find_methodology_analysis_loop() {
-    local loop_base_dir="$1"
-
-    if [[ ! -d "$loop_base_dir" ]]; then
-        echo ""
-        return
-    fi
-
-    local dir
-    while IFS= read -r dir; do
-        [[ -z "$dir" ]] && continue
-        local trimmed_dir="${dir%/}"
-        if [[ -f "$trimmed_dir/methodology-analysis-state.md" ]]; then
-            echo "$trimmed_dir"
-            return
-        fi
-    done < <(ls -1d "$loop_base_dir"/*/ 2>/dev/null | sort -r)
-
-    echo ""
-}
 
 # Extract current round number from state.md
 # Outputs the round number to stdout, defaults to 0

--- a/hooks/lib/loop-common.sh
+++ b/hooks/lib/loop-common.sh
@@ -38,6 +38,7 @@ readonly FIELD_FULL_REVIEW_ROUND="full_review_round"
 readonly FIELD_ASK_CODEX_QUESTION="ask_codex_question"
 readonly FIELD_SESSION_ID="session_id"
 readonly FIELD_AGENT_TEAMS="agent_teams"
+readonly FIELD_PRIVACY_MODE="privacy_mode"
 
 # Default Codex configuration (single source of truth - all scripts reference this)
 # Scripts can pre-set DEFAULT_CODEX_MODEL/DEFAULT_CODEX_EFFORT before sourcing to override.
@@ -216,7 +217,9 @@ extract_session_id() {
 resolve_active_state_file() {
     local loop_dir="$1"
 
-    if [[ -f "$loop_dir/finalize-state.md" ]]; then
+    if [[ -f "$loop_dir/methodology-analysis-state.md" ]]; then
+        echo "$loop_dir/methodology-analysis-state.md"
+    elif [[ -f "$loop_dir/finalize-state.md" ]]; then
         echo "$loop_dir/finalize-state.md"
     elif [[ -f "$loop_dir/state.md" ]]; then
         echo "$loop_dir/state.md"
@@ -234,7 +237,10 @@ resolve_any_state_file() {
     local loop_dir="$1"
 
     # Prefer active states
-    if [[ -f "$loop_dir/finalize-state.md" ]]; then
+    if [[ -f "$loop_dir/methodology-analysis-state.md" ]]; then
+        echo "$loop_dir/methodology-analysis-state.md"
+        return
+    elif [[ -f "$loop_dir/finalize-state.md" ]]; then
         echo "$loop_dir/finalize-state.md"
         return
     elif [[ -f "$loop_dir/state.md" ]]; then
@@ -364,6 +370,7 @@ _parse_state_fields() {
     STATE_ASK_CODEX_QUESTION=$(echo "$STATE_FRONTMATTER" | grep "^${FIELD_ASK_CODEX_QUESTION}:" | sed "s/${FIELD_ASK_CODEX_QUESTION}: *//" | tr -d ' ' || true)
     STATE_SESSION_ID=$(echo "$STATE_FRONTMATTER" | grep "^${FIELD_SESSION_ID}:" | sed "s/${FIELD_SESSION_ID}: *//" || true)
     STATE_AGENT_TEAMS=$(echo "$STATE_FRONTMATTER" | grep "^${FIELD_AGENT_TEAMS}:" | sed "s/${FIELD_AGENT_TEAMS}: *//" | tr -d ' ' || true)
+    STATE_PRIVACY_MODE=$(echo "$STATE_FRONTMATTER" | grep "^${FIELD_PRIVACY_MODE}:" | sed "s/${FIELD_PRIVACY_MODE}: *//" | tr -d ' ' || true)
 }
 
 # Parse state file frontmatter and set variables (tolerant mode with defaults)
@@ -406,6 +413,8 @@ parse_state_file() {
     STATE_FULL_REVIEW_ROUND="${STATE_FULL_REVIEW_ROUND:-5}"
     STATE_ASK_CODEX_QUESTION="${STATE_ASK_CODEX_QUESTION:-true}"
     STATE_AGENT_TEAMS="${STATE_AGENT_TEAMS:-false}"
+    # Default privacy_mode to "true" for legacy loops that pre-date this field
+    STATE_PRIVACY_MODE="${STATE_PRIVACY_MODE:-true}"
     # STATE_REVIEW_STARTED left as-is (empty if missing, to allow schema validation)
 
     return 0
@@ -683,6 +692,21 @@ is_finalize_state_file_path() {
     echo "$path_lower" | grep -qE 'finalize-state\.md$'
 }
 
+# Check if a path (lowercase) targets methodology-analysis-state.md
+is_methodology_analysis_state_file_path() {
+    local path_lower="$1"
+    echo "$path_lower" | grep -qE 'methodology-analysis-state\.md$'
+}
+
+# Standard message for blocking methodology-analysis-state file modifications
+methodology_analysis_state_file_blocked_message() {
+    local fallback="# Methodology Analysis State File Modification Blocked
+
+You cannot modify methodology-analysis-state.md. This file is managed by the loop system during the Methodology Analysis Phase."
+
+    load_and_render_safe "$TEMPLATE_DIR" "block/methodology-analysis-state-file-modification.md" "$fallback"
+}
+
 # Check if a path (lowercase) targets finalize-summary.md
 is_finalize_summary_path() {
     local path_lower="$1"
@@ -847,7 +871,8 @@ is_cancel_authorized() {
     src=$(_normalize_path "$src")
     local expected_src_state="${loop_dir_lower}state.md"
     local expected_src_finalize="${loop_dir_lower}finalize-state.md"
-    if [[ "$src" != "$expected_src_state" ]] && [[ "$src" != "$expected_src_finalize" ]]; then
+    local expected_src_methodology="${loop_dir_lower}methodology-analysis-state.md"
+    if [[ "$src" != "$expected_src_state" ]] && [[ "$src" != "$expected_src_finalize" ]] && [[ "$src" != "$expected_src_methodology" ]]; then
         return 5
     fi
 
@@ -860,9 +885,11 @@ is_cancel_authorized() {
 
     # SECURITY: Reject if source file is a symlink (filesystem check)
     # Determine source file by comparing against expected paths (not substring match)
-    # This avoids vulnerability when loop directory path contains "finalize"
+    # This avoids vulnerability when loop directory path contains "finalize" or "methodology"
     local src_original
-    if [[ "$src" == "$expected_src_finalize" ]]; then
+    if [[ "$src" == "$expected_src_methodology" ]]; then
+        src_original="${active_loop_dir}/methodology-analysis-state.md"
+    elif [[ "$src" == "$expected_src_finalize" ]]; then
         src_original="${active_loop_dir}/finalize-state.md"
     else
         src_original="${active_loop_dir}/state.md"

--- a/hooks/lib/loop-common.sh
+++ b/hooks/lib/loop-common.sh
@@ -332,6 +332,38 @@ find_active_loop() {
     echo ""
 }
 
+# Find any active loop directory currently in methodology analysis phase.
+# Unlike find_active_loop() which returns the newest active loop (possibly the
+# wrong one when multiple concurrent sessions exist), this function specifically
+# searches for a loop with methodology-analysis-state.md present.
+# This ensures spawned agents (which have different session_ids) always bind to
+# the correct originating loop during methodology analysis.
+#
+# Args:
+#   $1 - loop_base_dir: path to .humanize/rlcr
+#
+# Outputs the directory path to stdout, or empty string if none found
+find_methodology_analysis_loop() {
+    local loop_base_dir="$1"
+
+    if [[ ! -d "$loop_base_dir" ]]; then
+        echo ""
+        return
+    fi
+
+    local dir
+    while IFS= read -r dir; do
+        [[ -z "$dir" ]] && continue
+        local trimmed_dir="${dir%/}"
+        if [[ -f "$trimmed_dir/methodology-analysis-state.md" ]]; then
+            echo "$trimmed_dir"
+            return
+        fi
+    done < <(ls -1d "$loop_base_dir"/*/ 2>/dev/null | sort -r)
+
+    echo ""
+}
+
 # Extract current round number from state.md
 # Outputs the round number to stdout, defaults to 0
 # Note: For full state parsing, use parse_state_file() instead

--- a/hooks/lib/methodology-analysis.sh
+++ b/hooks/lib/methodology-analysis.sh
@@ -126,9 +126,16 @@ complete_methodology_analysis() {
         return 1
     fi
 
-    # Require the analysis report to exist (ensures the Opus agent actually ran)
+    # Require the analysis report to exist with content (ensures the Opus agent
+    # actually produced an analysis, not just an empty/truncated file)
     if [[ ! -f "$report_file" ]]; then
         echo "Warning: methodology-analysis-report.md missing, blocking completion" >&2
+        return 1
+    fi
+    local report_content
+    report_content=$(cat "$report_file" 2>/dev/null || echo "")
+    if [[ -z "$report_content" ]]; then
+        echo "Warning: methodology-analysis-report.md is empty, blocking completion" >&2
         return 1
     fi
 

--- a/hooks/lib/methodology-analysis.sh
+++ b/hooks/lib/methodology-analysis.sh
@@ -109,10 +109,11 @@ When done, write a completion note to $LOOP_DIR/methodology-analysis-done.md."
 #
 # Returns:
 #   0 - completion successful, caller should exit 0 (allow exit)
-#   1 - completion artifact missing or empty, caller should block
+#   1 - incomplete (done marker missing/empty, report missing, or exit reason invalid)
 #
 complete_methodology_analysis() {
     local done_file="$LOOP_DIR/methodology-analysis-done.md"
+    local report_file="$LOOP_DIR/methodology-analysis-report.md"
 
     # Check completion artifact has actual content (not just empty placeholder)
     if [[ ! -f "$done_file" ]]; then
@@ -125,20 +126,29 @@ complete_methodology_analysis() {
         return 1
     fi
 
-    # Read exit reason
-    local exit_reason="complete"
-    if [[ -f "$LOOP_DIR/.methodology-exit-reason" ]]; then
-        exit_reason=$(cat "$LOOP_DIR/.methodology-exit-reason" 2>/dev/null || echo "complete")
-        exit_reason=$(echo "$exit_reason" | tr -d '[:space:]')
+    # Require the analysis report to exist (ensures the Opus agent actually ran)
+    if [[ ! -f "$report_file" ]]; then
+        echo "Warning: methodology-analysis-report.md missing, blocking completion" >&2
+        return 1
     fi
 
-    # Validate exit reason
+    # Read exit reason (fail closed: missing marker blocks completion)
+    if [[ ! -f "$LOOP_DIR/.methodology-exit-reason" ]]; then
+        echo "Error: .methodology-exit-reason marker missing, cannot determine terminal state" >&2
+        return 1
+    fi
+
+    local exit_reason
+    exit_reason=$(cat "$LOOP_DIR/.methodology-exit-reason" 2>/dev/null || echo "")
+    exit_reason=$(echo "$exit_reason" | tr -d '[:space:]')
+
+    # Validate exit reason (fail closed on invalid values)
     case "$exit_reason" in
         complete|stop|maxiter)
             ;;
         *)
-            echo "Warning: Invalid methodology exit reason '$exit_reason', defaulting to complete" >&2
-            exit_reason="complete"
+            echo "Error: Invalid methodology exit reason '$exit_reason', blocking completion" >&2
+            return 1
             ;;
     esac
 

--- a/hooks/lib/methodology-analysis.sh
+++ b/hooks/lib/methodology-analysis.sh
@@ -1,0 +1,186 @@
+#!/bin/bash
+#
+# Methodology Analysis Phase library
+#
+# Provides functions for the methodology improvement analysis phase that runs
+# before the RLCR loop truly exits. An independent Opus agent analyzes the
+# development records from a pure methodology perspective and optionally helps
+# the user file a GitHub issue with improvement suggestions.
+#
+# This library is sourced by loop-codex-stop-hook.sh.
+#
+
+# Source guard: prevent double-sourcing
+[[ -n "${_METHODOLOGY_ANALYSIS_LOADED:-}" ]] && return 0 2>/dev/null || true
+_METHODOLOGY_ANALYSIS_LOADED=1
+
+# Enter the methodology analysis phase
+#
+# Renames the current state file to methodology-analysis-state.md, records the
+# exit reason, renders the analysis prompt, and outputs a block JSON response.
+#
+# Arguments:
+#   $1 - exit_reason: "complete", "stop", or "maxiter"
+#   $2 - exit_reason_description: human-readable explanation of why the loop is exiting
+#
+# Globals read:
+#   PRIVACY_MODE - "true" to skip analysis, "false" to proceed
+#   STATE_FILE   - path to the current active state file
+#   LOOP_DIR     - path to the loop directory
+#   CURRENT_ROUND - current round number
+#   MAX_ITERATIONS - max iterations setting
+#   TEMPLATE_DIR - template directory for prompt rendering
+#
+# Returns:
+#   0 - analysis phase entered, block JSON has been output, caller should exit 0
+#   1 - analysis should be skipped (privacy on, already done, or re-entry)
+#
+enter_methodology_analysis_phase() {
+    local exit_reason="$1"
+    local exit_reason_description="$2"
+
+    # Skip if privacy mode is on
+    if [[ "$PRIVACY_MODE" == "true" ]]; then
+        echo "Methodology analysis skipped (privacy mode enabled)" >&2
+        return 1
+    fi
+
+    # Prevent re-entry: if methodology-analysis-state.md already exists, skip
+    if [[ -f "$LOOP_DIR/methodology-analysis-state.md" ]]; then
+        echo "Methodology analysis phase already active, skipping re-entry" >&2
+        return 1
+    fi
+
+    # Skip if already completed in a previous attempt
+    if [[ -f "$LOOP_DIR/methodology-analysis-done.md" ]]; then
+        local done_content
+        done_content=$(cat "$LOOP_DIR/methodology-analysis-done.md" 2>/dev/null || echo "")
+        if [[ -n "$done_content" ]]; then
+            echo "Methodology analysis already completed, skipping" >&2
+            return 1
+        fi
+    fi
+
+    # Rename current state file to methodology-analysis-state.md
+    mv "$STATE_FILE" "$LOOP_DIR/methodology-analysis-state.md"
+    echo "State file renamed to: $LOOP_DIR/methodology-analysis-state.md" >&2
+
+    # Record the original exit reason so the completion handler can finalize
+    echo "$exit_reason" > "$LOOP_DIR/.methodology-exit-reason"
+
+    # Create empty placeholder for the completion artifact
+    touch "$LOOP_DIR/methodology-analysis-done.md"
+
+    # Render prompt template
+    local fallback="# Methodology Analysis Phase
+
+Please analyze the development records in $LOOP_DIR and provide methodology improvement suggestions.
+Write your analysis to $LOOP_DIR/methodology-analysis-report.md.
+When done, write a completion note to $LOOP_DIR/methodology-analysis-done.md."
+
+    local analysis_prompt
+    analysis_prompt=$(load_and_render_safe "$TEMPLATE_DIR" "claude/methodology-analysis-prompt.md" "$fallback" \
+        "LOOP_DIR=$LOOP_DIR" \
+        "EXIT_REASON=$exit_reason" \
+        "EXIT_REASON_DESCRIPTION=$exit_reason_description" \
+        "CURRENT_ROUND=$CURRENT_ROUND" \
+        "MAX_ITERATIONS=$MAX_ITERATIONS")
+
+    # Output block JSON with the rendered prompt
+    jq -n \
+        --arg reason "$analysis_prompt" \
+        --arg msg "Loop: Methodology Analysis Phase - analyzing development methodology" \
+        '{
+            "decision": "block",
+            "reason": $reason,
+            "systemMessage": $msg
+        }'
+
+    return 0
+}
+
+# Complete the methodology analysis phase
+#
+# Checks the completion artifact, reads the original exit reason, renames the
+# state file to the appropriate terminal state, and cleans up marker files.
+#
+# Globals read:
+#   LOOP_DIR - path to the loop directory
+#
+# Returns:
+#   0 - completion successful, caller should exit 0 (allow exit)
+#   1 - completion artifact missing or empty, caller should block
+#
+complete_methodology_analysis() {
+    local done_file="$LOOP_DIR/methodology-analysis-done.md"
+
+    # Check completion artifact has actual content (not just empty placeholder)
+    if [[ ! -f "$done_file" ]]; then
+        return 1
+    fi
+
+    local done_content
+    done_content=$(cat "$done_file" 2>/dev/null || echo "")
+    if [[ -z "$done_content" ]]; then
+        return 1
+    fi
+
+    # Read exit reason
+    local exit_reason="complete"
+    if [[ -f "$LOOP_DIR/.methodology-exit-reason" ]]; then
+        exit_reason=$(cat "$LOOP_DIR/.methodology-exit-reason" 2>/dev/null || echo "complete")
+        exit_reason=$(echo "$exit_reason" | tr -d '[:space:]')
+    fi
+
+    # Validate exit reason
+    case "$exit_reason" in
+        complete|stop|maxiter)
+            ;;
+        *)
+            echo "Warning: Invalid methodology exit reason '$exit_reason', defaulting to complete" >&2
+            exit_reason="complete"
+            ;;
+    esac
+
+    # Rename methodology-analysis-state.md to the terminal state
+    local target_name="${exit_reason}-state.md"
+    mv "$LOOP_DIR/methodology-analysis-state.md" "$LOOP_DIR/$target_name"
+    echo "Methodology analysis complete. State preserved as: $LOOP_DIR/$target_name" >&2
+
+    # Clean up marker file
+    rm -f "$LOOP_DIR/.methodology-exit-reason"
+
+    return 0
+}
+
+# Block exit because methodology analysis is incomplete
+#
+# Outputs a block JSON instructing Claude to complete the analysis before exiting.
+#
+# Globals read:
+#   LOOP_DIR - path to the loop directory
+#
+block_methodology_analysis_incomplete() {
+    local done_file="$LOOP_DIR/methodology-analysis-done.md"
+
+    local reason="# Methodology Analysis Incomplete
+
+Please complete the methodology analysis before exiting.
+
+You need to:
+1. Spawn an Opus agent to analyze the development records
+2. Review the analysis report
+3. Optionally help the user file a GitHub issue
+4. Write a completion note to: $done_file
+
+The completion marker file must contain actual content (not be empty) to signal that the analysis is done."
+
+    jq -n \
+        --arg reason "$reason" \
+        --arg msg "Loop: Methodology Analysis Phase - please complete the analysis" \
+        '{
+            "decision": "block",
+            "reason": $reason,
+            "systemMessage": $msg
+        }'
+}

--- a/hooks/loop-bash-validator.sh
+++ b/hooks/loop-bash-validator.sh
@@ -83,14 +83,14 @@ if [[ -n "$_MA_BASH_DIR" ]] && [[ -f "$_MA_BASH_DIR/methodology-analysis-state.m
         exit 0
     fi
     # Block git commands that modify the working tree
-    if echo "$COMMAND_LOWER" | grep -qE '(^|[[:space:];|&])git[[:space:]]+(commit|add|reset|checkout|merge|rebase|cherry-pick|am|apply|stash|push|restore|clean|rm|mv)'; then
+    if echo "$COMMAND_LOWER" | grep -qE '(^|[[:space:];|&])git[[:space:]]+(commit|add|reset|checkout|merge|rebase|cherry-pick|am|apply|stash|push|restore|clean|rm|mv|switch|pull|clone|submodule|worktree)'; then
         echo "# Bash Blocked During Methodology Analysis
 
 Git write commands are not allowed during the methodology analysis phase." >&2
         exit 2
     fi
-    # Block file manipulation commands (touch, mv, cp, rm, etc.)
-    if echo "$COMMAND_LOWER" | grep -qE '(^|[[:space:];|&])(tee|install|touch|mv|cp|rm|dd|truncate|chmod|chown)[[:space:]]'; then
+    # Block file manipulation commands (touch, mv, cp, rm, mkdir, ln, etc.)
+    if echo "$COMMAND_LOWER" | grep -qE '(^|[[:space:];|&])(tee|install|touch|mv|cp|rm|dd|truncate|chmod|chown|mkdir|rmdir|ln|mktemp)[[:space:]]'; then
         echo "# Bash Blocked During Methodology Analysis
 
 File modification commands are not allowed during the methodology analysis phase." >&2

--- a/hooks/loop-bash-validator.sh
+++ b/hooks/loop-bash-validator.sh
@@ -81,9 +81,8 @@ if [[ -z "$_MA_BASH_DIR" ]] || [[ ! -f "$_MA_BASH_DIR/methodology-analysis-state
 fi
 
 if [[ -n "$_MA_BASH_DIR" ]] && [[ -f "$_MA_BASH_DIR/methodology-analysis-state.md" ]]; then
-    # Allow only gh issue commands (for optional feedback issue creation)
-    # Block other gh subcommands (pr checkout, repo clone, api, etc.)
-    if [[ "$COMMAND_LOWER" =~ ^[[:space:]]*gh[[:space:]]+issue[[:space:]] ]]; then
+    # Allow cancel-rlcr-loop.sh (user must be able to cancel during this phase)
+    if echo "$COMMAND_LOWER" | grep -qE '(^|[[:space:]])([^[:space:]]*/)?cancel-rlcr-loop\.sh'; then
         exit 0
     fi
     # Block git commands that modify the working tree

--- a/hooks/loop-bash-validator.sh
+++ b/hooks/loop-bash-validator.sh
@@ -78,8 +78,9 @@ if [[ -z "$_MA_BASH_DIR" ]]; then
 fi
 
 if [[ -n "$_MA_BASH_DIR" ]] && [[ -f "$_MA_BASH_DIR/methodology-analysis-state.md" ]]; then
-    # Allow gh commands for issue creation
-    if [[ "$COMMAND_LOWER" =~ ^[[:space:]]*gh[[:space:]] ]]; then
+    # Allow only gh issue commands (for optional feedback issue creation)
+    # Block other gh subcommands (pr checkout, repo clone, api, etc.)
+    if [[ "$COMMAND_LOWER" =~ ^[[:space:]]*gh[[:space:]]+issue[[:space:]] ]]; then
         exit 0
     fi
     # Block git commands that modify the working tree

--- a/hooks/loop-bash-validator.sh
+++ b/hooks/loop-bash-validator.sh
@@ -98,6 +98,35 @@ if [[ -n "$ACTIVE_LOOP_DIR" ]]; then
     CURRENT_ROUND="$STATE_CURRENT_ROUND"
 
     # ========================================
+    # Methodology Analysis Phase Bash Restriction
+    # ========================================
+    # During methodology analysis, block file-modifying bash commands.
+    # Only gh commands and read-only operations are allowed.
+    # This prevents source code modifications after Codex has signed off.
+
+    if [[ "$STATE_FILE" == *"/methodology-analysis-state.md" ]]; then
+        # Allow gh commands for issue creation
+        if [[ "$COMMAND_LOWER" =~ ^[[:space:]]*gh[[:space:]] ]]; then
+            exit 0
+        fi
+        # Block git commands that modify the working tree
+        if echo "$COMMAND_LOWER" | grep -qE '(^|[[:space:];|&])git[[:space:]]+(commit|add|reset|checkout|merge|rebase|cherry-pick|am|apply|stash|push)'; then
+            echo "# Bash Blocked During Methodology Analysis
+
+Git commands that modify the working tree are not allowed during the methodology analysis phase." >&2
+            exit 2
+        fi
+        # Block in-place file editing tools (bypass for Write/Edit tool restriction)
+        if echo "$COMMAND_LOWER" | grep -qE '(^|[[:space:];|&])(tee|install)[[:space:]]' || \
+           echo "$COMMAND_LOWER" | grep -qE 'sed[[:space:]]+-i|awk[[:space:]]+-i[[:space:]]+inplace|perl[[:space:]]+-[^[:space:]]*i'; then
+            echo "# Bash Blocked During Methodology Analysis
+
+File modification commands are not allowed during the methodology analysis phase." >&2
+            exit 2
+        fi
+    fi
+
+    # ========================================
     # Block Git Push When push_every_round is false
     # ========================================
     # Default behavior: commits stay local, no need to push to remote

--- a/hooks/loop-bash-validator.sh
+++ b/hooks/loop-bash-validator.sh
@@ -72,13 +72,10 @@ ACTIVE_PR_LOOP_DIR=$(find_active_pr_loop "$PR_LOOP_BASE_DIR")
 # This prevents source code modifications after Codex has signed off.
 # Uses unfiltered search to also apply to spawned agents with different session_id.
 
+# Use only the session-matched loop. Do NOT fall back to an unfiltered search,
+# as that would incorrectly restrict unrelated sessions opened in the same repo.
+# Spawned agents (with different session_ids) are guided by their prompt instead.
 _MA_BASH_DIR="$ACTIVE_LOOP_DIR"
-if [[ -z "$_MA_BASH_DIR" ]]; then
-    # Only fall back when NO session-matched loop was found (spawned agent case).
-    # If the session has its own active loop, do NOT search for another session's
-    # methodology analysis -- that would incorrectly restrict the current session.
-    _MA_BASH_DIR=$(find_methodology_analysis_loop "$LOOP_BASE_DIR")
-fi
 
 if [[ -n "$_MA_BASH_DIR" ]] && [[ -f "$_MA_BASH_DIR/methodology-analysis-state.md" ]]; then
     # Allow cancel-rlcr-loop.sh (user must be able to cancel during this phase)

--- a/hooks/loop-bash-validator.sh
+++ b/hooks/loop-bash-validator.sh
@@ -68,18 +68,22 @@ ACTIVE_PR_LOOP_DIR=$(find_active_pr_loop "$PR_LOOP_BASE_DIR")
 # Methodology Analysis Phase Bash Restriction
 # ========================================
 # During methodology analysis, block file-modifying bash commands.
-# Only gh commands and read-only operations are allowed.
+# Only read-only operations and cancel-rlcr-loop.sh are allowed.
 # This prevents source code modifications after Codex has signed off.
-# Uses unfiltered search to also apply to spawned agents with different session_id.
-
+#
 # Use only the session-matched loop. Do NOT fall back to an unfiltered search,
 # as that would incorrectly restrict unrelated sessions opened in the same repo.
-# Spawned agents (with different session_ids) are guided by their prompt instead.
+# Limitation: Spawned agents (different session_id) are not restricted by hooks;
+# their sanitization is enforced by the analysis prompt. This is an inherent
+# limitation of the hook architecture which cannot distinguish spawned agents
+# from unrelated sessions.
 _MA_BASH_DIR="$ACTIVE_LOOP_DIR"
 
 if [[ -n "$_MA_BASH_DIR" ]] && [[ -f "$_MA_BASH_DIR/methodology-analysis-state.md" ]]; then
     # Allow cancel-rlcr-loop.sh (user must be able to cancel during this phase)
-    if echo "$COMMAND_LOWER" | grep -qE '(^|[[:space:]])([^[:space:]]*/)?cancel-rlcr-loop\.sh'; then
+    # Only allow standalone invocation -- reject if chained with shell operators
+    if echo "$COMMAND_LOWER" | grep -qE '(^|[[:space:]])([^[:space:]]*/)?cancel-rlcr-loop\.sh' && \
+       ! echo "$COMMAND_LOWER" | grep -qE '[;|&]'; then
         exit 0
     fi
     # Block git commands that modify the working tree

--- a/hooks/loop-bash-validator.sh
+++ b/hooks/loop-bash-validator.sh
@@ -148,6 +148,15 @@ if [[ -n "$ACTIVE_LOOP_DIR" ]]; then
 # 1. command_modifies_file checks if DESTINATION contains state.md
 # 2. Additional check below catches if SOURCE contains state.md (e.g., mv state.md /tmp/foo)
 
+if command_modifies_file "$COMMAND_LOWER" "methodology-analysis-state\.md"; then
+    # Check for cancel signal file - allow authorized cancel operation
+    if is_cancel_authorized "$ACTIVE_LOOP_DIR" "$COMMAND_LOWER"; then
+        exit 0
+    fi
+    methodology_analysis_state_file_blocked_message >&2
+    exit 2
+fi
+
 if command_modifies_file "$COMMAND_LOWER" "finalize-state\.md"; then
     # Check for cancel signal file - allow authorized cancel operation
     if is_cancel_authorized "$ACTIVE_LOOP_DIR" "$COMMAND_LOWER"; then
@@ -182,6 +191,7 @@ fi
 # This catches chained commands like: true; mv state.md /tmp/foo
 MV_CP_SOURCE_PATTERN="^[[:space:]]*(sudo([[:space:]]+-?[^[:space:];&|]+)*[[:space:]]+)?(env[[:space:]]+[^;&|]*[[:space:]]+)?(command([[:space:]]+-?[^[:space:];&|]+)*[[:space:]]+)?(mv|cp)[[:space:]].*[[:space:]/\"']state\.md"
 MV_CP_FINALIZE_SOURCE_PATTERN="^[[:space:]]*(sudo([[:space:]]+-?[^[:space:];&|]+)*[[:space:]]+)?(env[[:space:]]+[^;&|]*[[:space:]]+)?(command([[:space:]]+-?[^[:space:];&|]+)*[[:space:]]+)?(mv|cp)[[:space:]].*[[:space:]/\"']finalize-state\.md"
+MV_CP_METHODOLOGY_SOURCE_PATTERN="^[[:space:]]*(sudo([[:space:]]+-?[^[:space:];&|]+)*[[:space:]]+)?(env[[:space:]]+[^;&|]*[[:space:]]+)?(command([[:space:]]+-?[^[:space:];&|]+)*[[:space:]]+)?(mv|cp)[[:space:]].*[[:space:]/\"']methodology-analysis-state\.md"
 
 # Replace shell operators with newlines, then check each segment
 # Order matters: |& before |, && before single &
@@ -295,7 +305,17 @@ while IFS= read -r SEGMENT; do
         t again
     ')
 
-    # Check for finalize-state.md as SOURCE first (more specific pattern)
+    # Check for methodology-analysis-state.md as SOURCE first (most specific pattern)
+    if echo "$SEGMENT_CLEANED" | grep -qE "$MV_CP_METHODOLOGY_SOURCE_PATTERN"; then
+        # Check for cancel signal file - allow authorized cancel operation
+        if is_cancel_authorized "$ACTIVE_LOOP_DIR" "$COMMAND_LOWER"; then
+            exit 0
+        fi
+        methodology_analysis_state_file_blocked_message >&2
+        exit 2
+    fi
+
+    # Check for finalize-state.md as SOURCE (more specific than state.md)
     if echo "$SEGMENT_CLEANED" | grep -qE "$MV_CP_FINALIZE_SOURCE_PATTERN"; then
         # Check for cancel signal file - allow authorized cancel operation
         if is_cancel_authorized "$ACTIVE_LOOP_DIR" "$COMMAND_LOWER"; then
@@ -319,6 +339,14 @@ done <<< "$COMMAND_SEGMENTS"
 # This catches bypass attempts like: sh -c 'mv state.md /tmp/foo'
 # Pattern: look for sh/bash with -c flag and state.md or finalize-state.md in the payload
 if echo "$COMMAND_LOWER" | grep -qE "(^|[[:space:]/])(sh|bash)[[:space:]]+-c[[:space:]]"; then
+    # Shell wrapper detected - check if payload contains mv/cp methodology-analysis-state.md (most specific)
+    if echo "$COMMAND_LOWER" | grep -qE "(mv|cp)[[:space:]].*methodology-analysis-state\.md"; then
+        if is_cancel_authorized "$ACTIVE_LOOP_DIR" "$COMMAND_LOWER"; then
+            exit 0
+        fi
+        methodology_analysis_state_file_blocked_message >&2
+        exit 2
+    fi
     # Shell wrapper detected - check if payload contains mv/cp finalize-state.md (check first, more specific)
     if echo "$COMMAND_LOWER" | grep -qE "(mv|cp)[[:space:]].*finalize-state\.md"; then
         # Check for cancel signal file - allow authorized cancel operation

--- a/hooks/loop-bash-validator.sh
+++ b/hooks/loop-bash-validator.sh
@@ -104,6 +104,13 @@ File modification commands are not allowed during the methodology analysis phase
 In-place file editing is not allowed during the methodology analysis phase." >&2
         exit 2
     fi
+    # Block common interpreters that could write files (defense-in-depth)
+    if echo "$COMMAND_LOWER" | grep -qE '(^|[[:space:];|&])(python[23]?|ruby|node|perl|php)[[:space:]]'; then
+        echo "# Bash Blocked During Methodology Analysis
+
+Running interpreters is not allowed during the methodology analysis phase." >&2
+        exit 2
+    fi
     # Block output redirection to files (catches cat > file, echo > file, etc.)
     # Strip safe redirections (/dev/ paths, fd duplication) then check for remaining >
     _ma_stripped=$(echo "$COMMAND_LOWER" | sed 's|[0-9]*>[>]*[[:space:]]*/dev/[^[:space:]]*||g; s|[0-9]*>&[0-9]*||g')

--- a/hooks/loop-bash-validator.sh
+++ b/hooks/loop-bash-validator.sh
@@ -71,12 +71,17 @@ ACTIVE_PR_LOOP_DIR=$(find_active_pr_loop "$PR_LOOP_BASE_DIR")
 # Only read-only operations and cancel-rlcr-loop.sh are allowed.
 # This prevents source code modifications after Codex has signed off.
 #
+# Accepted limitations:
+# - Read-only bash commands (cat, grep, find, etc.) are NOT blocked. Blocking
+#   them would break basic Claude operations. The analysis prompt directs Claude
+#   to derive user-facing content only from methodology-analysis-report.md.
+# - Spawned agents (different session_id) are not restricted by hooks; their
+#   sanitization is enforced by the analysis prompt. This is an inherent
+#   limitation of the hook architecture which cannot distinguish spawned agents
+#   from unrelated sessions.
+#
 # Use only the session-matched loop. Do NOT fall back to an unfiltered search,
 # as that would incorrectly restrict unrelated sessions opened in the same repo.
-# Limitation: Spawned agents (different session_id) are not restricted by hooks;
-# their sanitization is enforced by the analysis prompt. This is an inherent
-# limitation of the hook architecture which cannot distinguish spawned agents
-# from unrelated sessions.
 _MA_BASH_DIR="$ACTIVE_LOOP_DIR"
 
 if [[ -n "$_MA_BASH_DIR" ]] && [[ -f "$_MA_BASH_DIR/methodology-analysis-state.md" ]]; then

--- a/hooks/loop-bash-validator.sh
+++ b/hooks/loop-bash-validator.sh
@@ -73,8 +73,11 @@ ACTIVE_PR_LOOP_DIR=$(find_active_pr_loop "$PR_LOOP_BASE_DIR")
 # Uses unfiltered search to also apply to spawned agents with different session_id.
 
 _MA_BASH_DIR="$ACTIVE_LOOP_DIR"
-if [[ -z "$_MA_BASH_DIR" ]]; then
-    _MA_BASH_DIR=$(find_active_loop "$LOOP_BASE_DIR" "")
+if [[ -z "$_MA_BASH_DIR" ]] || [[ ! -f "$_MA_BASH_DIR/methodology-analysis-state.md" ]]; then
+    # Spawned agents have a different session_id, so session-filtered search may
+    # miss the originating loop. Use targeted search that scans ALL loops for
+    # methodology-analysis-state.md to avoid binding to a wrong concurrent session.
+    _MA_BASH_DIR=$(find_methodology_analysis_loop "$LOOP_BASE_DIR")
 fi
 
 if [[ -n "$_MA_BASH_DIR" ]] && [[ -f "$_MA_BASH_DIR/methodology-analysis-state.md" ]]; then
@@ -109,6 +112,34 @@ In-place file editing is not allowed during the methodology analysis phase." >&2
         echo "# Bash Blocked During Methodology Analysis
 
 Running interpreters is not allowed during the methodology analysis phase." >&2
+        exit 2
+    fi
+    # Block shell script entry points (bash script.sh, sh script.sh, source, .)
+    if echo "$COMMAND_LOWER" | grep -qE '(^|[[:space:];|&])(/usr/bin/env[[:space:]]+)?(bash|sh|zsh|/bin/bash|/bin/sh|/bin/zsh)[[:space:]]'; then
+        echo "# Bash Blocked During Methodology Analysis
+
+Running shell scripts is not allowed during the methodology analysis phase." >&2
+        exit 2
+    fi
+    # Block build tools that execute arbitrary commands
+    if echo "$COMMAND_LOWER" | grep -qE '(^|[[:space:];|&])(make|cmake|ninja|gradle|mvn|ant|cargo|go[[:space:]]+run|go[[:space:]]+generate|npm[[:space:]]+run|yarn[[:space:]]+run|npx|pnpm)[[:space:]]'; then
+        echo "# Bash Blocked During Methodology Analysis
+
+Build tools are not allowed during the methodology analysis phase." >&2
+        exit 2
+    fi
+    # Block source/dot commands (source script.sh, . script.sh)
+    if echo "$COMMAND_LOWER" | grep -qE '(^|[[:space:];|&])(source|\.)[ 	]+[^[:space:]]'; then
+        echo "# Bash Blocked During Methodology Analysis
+
+Sourcing scripts is not allowed during the methodology analysis phase." >&2
+        exit 2
+    fi
+    # Block direct script execution (./script.sh, ../script.sh, /path/to/script)
+    if echo "$COMMAND_LOWER" | grep -qE '(^|[[:space:];|&])\.{0,2}/[^[:space:]>|&;]*\.(sh|bash|py|rb|pl|js)'; then
+        echo "# Bash Blocked During Methodology Analysis
+
+Direct script execution is not allowed during the methodology analysis phase." >&2
         exit 2
     fi
     # Block output redirection to files (catches cat > file, echo > file, etc.)

--- a/hooks/loop-bash-validator.sh
+++ b/hooks/loop-bash-validator.sh
@@ -85,9 +85,9 @@ ACTIVE_PR_LOOP_DIR=$(find_active_pr_loop "$PR_LOOP_BASE_DIR")
 _MA_BASH_DIR="$ACTIVE_LOOP_DIR"
 
 if [[ -n "$_MA_BASH_DIR" ]] && [[ -f "$_MA_BASH_DIR/methodology-analysis-state.md" ]]; then
-    # Allow cancel-rlcr-loop.sh (user must be able to cancel during this phase)
-    # Only allow standalone invocation -- reject if chained with shell operators
-    if echo "$COMMAND_LOWER" | grep -qE '(^|[[:space:]])([^[:space:]]*/)?cancel-rlcr-loop\.sh' && \
+    # Allow cancel-rlcr-loop.sh only as the leading command (not as an argument
+    # to another command like cp/mv). Reject if chained with shell operators.
+    if echo "$COMMAND_LOWER" | grep -qE '^[[:space:]]*("?[^"]*/?)?cancel-rlcr-loop\.sh' && \
        ! echo "$COMMAND_LOWER" | grep -qE '[;|&]'; then
         exit 0
     fi

--- a/hooks/loop-bash-validator.sh
+++ b/hooks/loop-bash-validator.sh
@@ -64,6 +64,56 @@ ACTIVE_LOOP_DIR=$(find_active_loop "$LOOP_BASE_DIR" "$HOOK_SESSION_ID")
 PR_LOOP_BASE_DIR="$PROJECT_ROOT/.humanize/pr-loop"
 ACTIVE_PR_LOOP_DIR=$(find_active_pr_loop "$PR_LOOP_BASE_DIR")
 
+# ========================================
+# Methodology Analysis Phase Bash Restriction
+# ========================================
+# During methodology analysis, block file-modifying bash commands.
+# Only gh commands and read-only operations are allowed.
+# This prevents source code modifications after Codex has signed off.
+# Uses unfiltered search to also apply to spawned agents with different session_id.
+
+_MA_BASH_DIR="$ACTIVE_LOOP_DIR"
+if [[ -z "$_MA_BASH_DIR" ]]; then
+    _MA_BASH_DIR=$(find_active_loop "$LOOP_BASE_DIR" "")
+fi
+
+if [[ -n "$_MA_BASH_DIR" ]] && [[ -f "$_MA_BASH_DIR/methodology-analysis-state.md" ]]; then
+    # Allow gh commands for issue creation
+    if [[ "$COMMAND_LOWER" =~ ^[[:space:]]*gh[[:space:]] ]]; then
+        exit 0
+    fi
+    # Block git commands that modify the working tree
+    if echo "$COMMAND_LOWER" | grep -qE '(^|[[:space:];|&])git[[:space:]]+(commit|add|reset|checkout|merge|rebase|cherry-pick|am|apply|stash|push)'; then
+        echo "# Bash Blocked During Methodology Analysis
+
+Git write commands are not allowed during the methodology analysis phase." >&2
+        exit 2
+    fi
+    # Block file manipulation commands (touch, mv, cp, rm, etc.)
+    if echo "$COMMAND_LOWER" | grep -qE '(^|[[:space:];|&])(tee|install|touch|mv|cp|rm|dd|truncate|chmod|chown)[[:space:]]'; then
+        echo "# Bash Blocked During Methodology Analysis
+
+File modification commands are not allowed during the methodology analysis phase." >&2
+        exit 2
+    fi
+    # Block in-place file editing tools
+    if echo "$COMMAND_LOWER" | grep -qE 'sed[[:space:]]+-i|awk[[:space:]]+-i[[:space:]]+inplace|perl[[:space:]]+-[^[:space:]]*i'; then
+        echo "# Bash Blocked During Methodology Analysis
+
+In-place file editing is not allowed during the methodology analysis phase." >&2
+        exit 2
+    fi
+    # Block output redirection to files (catches cat > file, echo > file, etc.)
+    # Strip safe redirections (/dev/ paths, fd duplication) then check for remaining >
+    _ma_stripped=$(echo "$COMMAND_LOWER" | sed 's|[0-9]*>[>]*[[:space:]]*/dev/[^[:space:]]*||g; s|[0-9]*>&[0-9]*||g')
+    if echo "$_ma_stripped" | grep -qE '[>]'; then
+        echo "# Bash Blocked During Methodology Analysis
+
+File redirection is not allowed during the methodology analysis phase." >&2
+        exit 2
+    fi
+fi
+
 # If no active loop of either type, allow all commands
 if [[ -z "$ACTIVE_LOOP_DIR" ]] && [[ -z "$ACTIVE_PR_LOOP_DIR" ]]; then
     exit 0
@@ -96,35 +146,6 @@ if [[ -n "$ACTIVE_LOOP_DIR" ]]; then
         exit 1
     fi
     CURRENT_ROUND="$STATE_CURRENT_ROUND"
-
-    # ========================================
-    # Methodology Analysis Phase Bash Restriction
-    # ========================================
-    # During methodology analysis, block file-modifying bash commands.
-    # Only gh commands and read-only operations are allowed.
-    # This prevents source code modifications after Codex has signed off.
-
-    if [[ "$STATE_FILE" == *"/methodology-analysis-state.md" ]]; then
-        # Allow gh commands for issue creation
-        if [[ "$COMMAND_LOWER" =~ ^[[:space:]]*gh[[:space:]] ]]; then
-            exit 0
-        fi
-        # Block git commands that modify the working tree
-        if echo "$COMMAND_LOWER" | grep -qE '(^|[[:space:];|&])git[[:space:]]+(commit|add|reset|checkout|merge|rebase|cherry-pick|am|apply|stash|push)'; then
-            echo "# Bash Blocked During Methodology Analysis
-
-Git commands that modify the working tree are not allowed during the methodology analysis phase." >&2
-            exit 2
-        fi
-        # Block in-place file editing tools (bypass for Write/Edit tool restriction)
-        if echo "$COMMAND_LOWER" | grep -qE '(^|[[:space:];|&])(tee|install)[[:space:]]' || \
-           echo "$COMMAND_LOWER" | grep -qE 'sed[[:space:]]+-i|awk[[:space:]]+-i[[:space:]]+inplace|perl[[:space:]]+-[^[:space:]]*i'; then
-            echo "# Bash Blocked During Methodology Analysis
-
-File modification commands are not allowed during the methodology analysis phase." >&2
-            exit 2
-        fi
-    fi
 
     # ========================================
     # Block Git Push When push_every_round is false

--- a/hooks/loop-bash-validator.sh
+++ b/hooks/loop-bash-validator.sh
@@ -73,10 +73,10 @@ ACTIVE_PR_LOOP_DIR=$(find_active_pr_loop "$PR_LOOP_BASE_DIR")
 # Uses unfiltered search to also apply to spawned agents with different session_id.
 
 _MA_BASH_DIR="$ACTIVE_LOOP_DIR"
-if [[ -z "$_MA_BASH_DIR" ]] || [[ ! -f "$_MA_BASH_DIR/methodology-analysis-state.md" ]]; then
-    # Spawned agents have a different session_id, so session-filtered search may
-    # miss the originating loop. Use targeted search that scans ALL loops for
-    # methodology-analysis-state.md to avoid binding to a wrong concurrent session.
+if [[ -z "$_MA_BASH_DIR" ]]; then
+    # Only fall back when NO session-matched loop was found (spawned agent case).
+    # If the session has its own active loop, do NOT search for another session's
+    # methodology analysis -- that would incorrectly restrict the current session.
     _MA_BASH_DIR=$(find_methodology_analysis_loop "$LOOP_BASE_DIR")
 fi
 
@@ -86,7 +86,7 @@ if [[ -n "$_MA_BASH_DIR" ]] && [[ -f "$_MA_BASH_DIR/methodology-analysis-state.m
         exit 0
     fi
     # Block git commands that modify the working tree
-    if echo "$COMMAND_LOWER" | grep -qE '(^|[[:space:];|&])git[[:space:]]+(commit|add|reset|checkout|merge|rebase|cherry-pick|am|apply|stash|push)'; then
+    if echo "$COMMAND_LOWER" | grep -qE '(^|[[:space:];|&])git[[:space:]]+(commit|add|reset|checkout|merge|rebase|cherry-pick|am|apply|stash|push|restore|clean|rm|mv)'; then
         echo "# Bash Blocked During Methodology Analysis
 
 Git write commands are not allowed during the methodology analysis phase." >&2

--- a/hooks/loop-codex-stop-hook.sh
+++ b/hooks/loop-codex-stop-hook.sh
@@ -50,6 +50,9 @@ source "$SCRIPT_DIR/lib/loop-common.sh"
 PLUGIN_ROOT="$(cd "$SCRIPT_DIR/.." && pwd)"
 source "$PLUGIN_ROOT/scripts/portable-timeout.sh"
 
+# Source methodology analysis library
+source "$SCRIPT_DIR/lib/methodology-analysis.sh"
+
 # Default timeout for git operations (30 seconds)
 GIT_TIMEOUT=30
 
@@ -79,6 +82,9 @@ fi
 
 IS_FINALIZE_PHASE=false
 [[ "$STATE_FILE" == *"/finalize-state.md" ]] && IS_FINALIZE_PHASE=true
+
+IS_METHODOLOGY_ANALYSIS_PHASE=false
+[[ "$STATE_FILE" == *"/methodology-analysis-state.md" ]] && IS_METHODOLOGY_ANALYSIS_PHASE=true
 
 # ========================================
 # Parse State File (using shared function)
@@ -120,6 +126,7 @@ CODEX_REVIEW_EFFORT="high"
 CODEX_TIMEOUT="${STATE_CODEX_TIMEOUT:-${CODEX_TIMEOUT:-$DEFAULT_CODEX_TIMEOUT}}"
 ASK_CODEX_QUESTION="${STATE_ASK_CODEX_QUESTION:-false}"
 AGENT_TEAMS="${STATE_AGENT_TEAMS:-false}"
+PRIVACY_MODE="${STATE_PRIVACY_MODE:-true}"
 BITLESSON_REQUIRED="false"
 if [[ -n "$RAW_BITLESSON_REQUIRED" ]]; then
     BITLESSON_REQUIRED=$(echo "$RAW_BITLESSON_REQUIRED" | sed 's/^bitlesson_required:[[:space:]]*//' | tr -d ' "')
@@ -676,6 +683,25 @@ Please push before exiting."
 fi
 
 # ========================================
+# Methodology Analysis Phase Completion Handler
+# ========================================
+# When in methodology analysis phase, check if the analysis is done.
+# If done, rename state to the original exit reason's terminal state.
+# If not done, block and ask Claude to complete the analysis.
+# All other checks (summary, bitlesson, goal tracker, max iterations) are skipped.
+
+if [[ "$IS_METHODOLOGY_ANALYSIS_PHASE" == "true" ]]; then
+    if complete_methodology_analysis; then
+        # Analysis complete, allow exit
+        exit 0
+    else
+        # Analysis not yet complete, block
+        block_methodology_analysis_incomplete
+        exit 0
+    fi
+fi
+
+# ========================================
 # Check Summary File Exists
 # ========================================
 
@@ -823,6 +849,10 @@ NEXT_ROUND=$((CURRENT_ROUND + 1))
 # - Review Phase: must continue until [P?] issues are cleared, regardless of iteration count
 if [[ "$IS_FINALIZE_PHASE" != "true" ]] && [[ "$REVIEW_STARTED" != "true" ]] && [[ $NEXT_ROUND -gt $MAX_ITERATIONS ]]; then
     echo "RLCR loop did not complete, but reached max iterations ($MAX_ITERATIONS). Exiting." >&2
+    # Try to enter methodology analysis phase before final exit
+    if enter_methodology_analysis_phase "maxiter" "Reached max iterations ($MAX_ITERATIONS) without completion"; then
+        exit 0
+    fi
     end_loop "$LOOP_DIR" "$STATE_FILE" "$EXIT_MAXITER"
     exit 0
 fi
@@ -834,8 +864,12 @@ fi
 # No Codex review is performed - this is the final step after Codex already confirmed COMPLETE
 
 if [[ "$IS_FINALIZE_PHASE" == "true" ]]; then
-    echo "Finalize Phase complete. All checks passed. Loop finished!" >&2
-    # Rename finalize-state.md to complete-state.md
+    echo "Finalize Phase complete. All checks passed." >&2
+    # Try to enter methodology analysis phase before final exit
+    if enter_methodology_analysis_phase "complete" "All acceptance criteria met and code review passed"; then
+        exit 0
+    fi
+    # Methodology analysis skipped or already done - proceed with normal exit
     mv "$STATE_FILE" "$LOOP_DIR/complete-state.md"
     echo "State preserved as: $LOOP_DIR/complete-state.md" >&2
     exit 0
@@ -1547,6 +1581,9 @@ if [[ "$LAST_LINE_TRIMMED" == "$MARKER_COMPLETE" ]]; then
         # Max iterations check
         if [[ $CURRENT_ROUND -ge $MAX_ITERATIONS ]]; then
             echo "Codex review passed but at max iterations ($MAX_ITERATIONS). Terminating as MAXITER." >&2
+            if enter_methodology_analysis_phase "maxiter" "Codex confirmed COMPLETE but at max iterations ($MAX_ITERATIONS)"; then
+                exit 0
+            fi
             end_loop "$LOOP_DIR" "$STATE_FILE" "$EXIT_MAXITER"
             exit 0
         fi
@@ -1640,6 +1677,10 @@ if [[ "$LAST_LINE_TRIMMED" == "$MARKER_STOP" ]]; then
         echo "  $REVIEW_RESULT_FILE" >&2
     fi
     echo "========================================" >&2
+    # Try to enter methodology analysis phase before final exit
+    if enter_methodology_analysis_phase "stop" "Circuit breaker triggered - stagnation detected at round $CURRENT_ROUND"; then
+        exit 0
+    fi
     end_loop "$LOOP_DIR" "$STATE_FILE" "$EXIT_STOP"
     exit 0
 fi

--- a/hooks/loop-codex-stop-hook.sh
+++ b/hooks/loop-codex-stop-hook.sh
@@ -583,6 +583,28 @@ Split these into smaller modules before continuing."
 fi
 
 # ========================================
+# Methodology Analysis Phase Completion Handler
+# ========================================
+# When in methodology analysis phase, check if the analysis is done.
+# If done, rename state to the original exit reason's terminal state.
+# If not done, block and ask Claude to complete the analysis.
+# All other checks (summary, bitlesson, goal tracker, max iterations) are skipped.
+# IMPORTANT: This MUST run before the git-clean check, because methodology
+# artifacts (.humanize/rlcr/...) may make the working tree appear dirty
+# if .humanize is tracked, which would block exit before reaching this handler.
+
+if [[ "$IS_METHODOLOGY_ANALYSIS_PHASE" == "true" ]]; then
+    if complete_methodology_analysis; then
+        # Analysis complete, allow exit
+        exit 0
+    else
+        # Analysis not yet complete, block
+        block_methodology_analysis_incomplete
+        exit 0
+    fi
+fi
+
+# ========================================
 # Quick Check: Git Clean and Pushed?
 # ========================================
 # Before running expensive Codex review, check if all changes have been
@@ -679,25 +701,6 @@ Please push before exiting."
                 }'
             exit 0
         fi
-    fi
-fi
-
-# ========================================
-# Methodology Analysis Phase Completion Handler
-# ========================================
-# When in methodology analysis phase, check if the analysis is done.
-# If done, rename state to the original exit reason's terminal state.
-# If not done, block and ask Claude to complete the analysis.
-# All other checks (summary, bitlesson, goal tracker, max iterations) are skipped.
-
-if [[ "$IS_METHODOLOGY_ANALYSIS_PHASE" == "true" ]]; then
-    if complete_methodology_analysis; then
-        # Analysis complete, allow exit
-        exit 0
-    else
-        # Analysis not yet complete, block
-        block_methodology_analysis_incomplete
-        exit 0
     fi
 fi
 

--- a/hooks/loop-edit-validator.sh
+++ b/hooks/loop-edit-validator.sh
@@ -80,6 +80,36 @@ if [[ "$IN_PR_LOOP_DIR" == "true" ]]; then
 fi
 
 # ========================================
+# Methodology Analysis Phase Edit Restriction
+# ========================================
+# During methodology analysis, only methodology artifacts can be edited.
+# This prevents source code modifications after Codex has signed off.
+# This check MUST come before the humanize loop dir early exit below.
+
+PROJECT_ROOT="${PROJECT_ROOT:-${CLAUDE_PROJECT_DIR:-$(pwd)}}"
+LOOP_BASE_DIR="${LOOP_BASE_DIR:-$PROJECT_ROOT/.humanize/rlcr}"
+_MA_LOOP_DIR="${LOOP_DIR:-$(find_active_loop "$LOOP_BASE_DIR" "$HOOK_SESSION_ID")}"
+
+if [[ -n "$_MA_LOOP_DIR" ]] && [[ -f "$_MA_LOOP_DIR/methodology-analysis-state.md" ]]; then
+    _ma_real_path=$(realpath "$FILE_PATH" 2>/dev/null || echo "")
+    _ma_real_loop=$(realpath "$_MA_LOOP_DIR" 2>/dev/null || echo "")
+    if [[ -n "$_ma_real_path" ]] && [[ -n "$_ma_real_loop" ]] && \
+       [[ "$_ma_real_path" == "$_ma_real_loop/"* ]]; then
+        _ma_basename=$(basename "$_ma_real_path")
+        case "$_ma_basename" in
+            methodology-analysis-report.md|methodology-analysis-done.md)
+                exit 0
+                ;;
+        esac
+    fi
+    echo "# Edit Blocked During Methodology Analysis
+
+During the methodology analysis phase, only methodology artifacts can be edited.
+Allowed: methodology-analysis-report.md, methodology-analysis-done.md" >&2
+    exit 2
+fi
+
+# ========================================
 # Check if File is in .humanize/rlcr
 # ========================================
 

--- a/hooks/loop-edit-validator.sh
+++ b/hooks/loop-edit-validator.sh
@@ -97,7 +97,12 @@ if [[ -z "$_MA_LOOP_DIR" ]]; then
 fi
 
 if [[ -n "$_MA_LOOP_DIR" ]] && [[ -f "$_MA_LOOP_DIR/methodology-analysis-state.md" ]]; then
+    # If realpath fails (file doesn't exist yet on BSD/macOS), resolve parent dir
     _ma_real_path=$(realpath "$FILE_PATH" 2>/dev/null || echo "")
+    if [[ -z "$_ma_real_path" ]]; then
+        _ma_parent=$(realpath "$(dirname "$FILE_PATH")" 2>/dev/null || echo "")
+        [[ -n "$_ma_parent" ]] && _ma_real_path="$_ma_parent/$(basename "$FILE_PATH")"
+    fi
     _ma_real_loop=$(realpath "$_MA_LOOP_DIR" 2>/dev/null || echo "")
     if [[ -n "$_ma_real_path" ]] && [[ -n "$_ma_real_loop" ]] && \
        [[ "$_ma_real_path" == "$_ma_real_loop/"* ]]; then

--- a/hooks/loop-edit-validator.sh
+++ b/hooks/loop-edit-validator.sh
@@ -110,9 +110,14 @@ fi
 CURRENT_ROUND="$STATE_CURRENT_ROUND"
 
 # ========================================
-# Block State File Edits (state.md and finalize-state.md)
+# Block State File Edits (state.md, finalize-state.md, methodology-analysis-state.md)
 # ========================================
-# NOTE: Check finalize-state.md FIRST because is_state_file_path also matches finalize-state.md
+# NOTE: Check most specific patterns first because is_state_file_path matches any *state.md
+
+if is_methodology_analysis_state_file_path "$FILE_PATH_LOWER"; then
+    methodology_analysis_state_file_blocked_message >&2
+    exit 2
+fi
 
 if is_finalize_state_file_path "$FILE_PATH_LOWER"; then
     finalize_state_file_blocked_message >&2

--- a/hooks/loop-edit-validator.sh
+++ b/hooks/loop-edit-validator.sh
@@ -90,6 +90,12 @@ PROJECT_ROOT="${PROJECT_ROOT:-${CLAUDE_PROJECT_DIR:-$(pwd)}}"
 LOOP_BASE_DIR="${LOOP_BASE_DIR:-$PROJECT_ROOT/.humanize/rlcr}"
 _MA_LOOP_DIR="${LOOP_DIR:-$(find_active_loop "$LOOP_BASE_DIR" "$HOOK_SESSION_ID")}"
 
+# Spawned agents (e.g., Opus analysis agent) have a different session_id.
+# Try unfiltered search to detect methodology analysis phase for them.
+if [[ -z "$_MA_LOOP_DIR" ]]; then
+    _MA_LOOP_DIR=$(find_active_loop "$LOOP_BASE_DIR" "")
+fi
+
 if [[ -n "$_MA_LOOP_DIR" ]] && [[ -f "$_MA_LOOP_DIR/methodology-analysis-state.md" ]]; then
     _ma_real_path=$(realpath "$FILE_PATH" 2>/dev/null || echo "")
     _ma_real_loop=$(realpath "$_MA_LOOP_DIR" 2>/dev/null || echo "")

--- a/hooks/loop-edit-validator.sh
+++ b/hooks/loop-edit-validator.sh
@@ -88,14 +88,10 @@ fi
 
 PROJECT_ROOT="${PROJECT_ROOT:-${CLAUDE_PROJECT_DIR:-$(pwd)}}"
 LOOP_BASE_DIR="${LOOP_BASE_DIR:-$PROJECT_ROOT/.humanize/rlcr}"
+# Use only the session-matched loop. Do NOT fall back to an unfiltered search,
+# as that would incorrectly restrict unrelated sessions opened in the same repo.
+# Spawned agents (with different session_ids) are guided by their prompt instead.
 _MA_LOOP_DIR="${LOOP_DIR:-$(find_active_loop "$LOOP_BASE_DIR" "$HOOK_SESSION_ID")}"
-
-# Only fall back when NO session-matched loop was found (spawned agent case).
-# If the session has its own active loop, do NOT search for another session's
-# methodology analysis -- that would incorrectly restrict the current session.
-if [[ -z "$_MA_LOOP_DIR" ]]; then
-    _MA_LOOP_DIR=$(find_methodology_analysis_loop "$LOOP_BASE_DIR")
-fi
 
 if [[ -n "$_MA_LOOP_DIR" ]] && [[ -f "$_MA_LOOP_DIR/methodology-analysis-state.md" ]]; then
     # If realpath fails (file doesn't exist yet on BSD/macOS), resolve parent dir
@@ -105,8 +101,10 @@ if [[ -n "$_MA_LOOP_DIR" ]] && [[ -f "$_MA_LOOP_DIR/methodology-analysis-state.m
         [[ -n "$_ma_parent" ]] && _ma_real_path="$_ma_parent/$(basename "$FILE_PATH")"
     fi
     _ma_real_loop=$(realpath "$_MA_LOOP_DIR" 2>/dev/null || echo "")
-    if [[ -n "$_ma_real_path" ]] && [[ -n "$_ma_real_loop" ]] && \
-       [[ "$_ma_real_path" == "$_ma_real_loop/"* ]]; then
+    # Fallback to raw paths when realpath is unavailable (older macOS/BSD)
+    [[ -z "$_ma_real_path" ]] && _ma_real_path="$FILE_PATH"
+    [[ -z "$_ma_real_loop" ]] && _ma_real_loop="$_MA_LOOP_DIR"
+    if [[ "$_ma_real_path" == "$_ma_real_loop/"* ]]; then
         _ma_basename=$(basename "$_ma_real_path")
         case "$_ma_basename" in
             methodology-analysis-report.md|methodology-analysis-done.md)

--- a/hooks/loop-edit-validator.sh
+++ b/hooks/loop-edit-validator.sh
@@ -90,10 +90,10 @@ PROJECT_ROOT="${PROJECT_ROOT:-${CLAUDE_PROJECT_DIR:-$(pwd)}}"
 LOOP_BASE_DIR="${LOOP_BASE_DIR:-$PROJECT_ROOT/.humanize/rlcr}"
 _MA_LOOP_DIR="${LOOP_DIR:-$(find_active_loop "$LOOP_BASE_DIR" "$HOOK_SESSION_ID")}"
 
-# Spawned agents (e.g., Opus analysis agent) have a different session_id.
-# Use targeted search that scans ALL loops for methodology-analysis-state.md
-# to avoid binding to a wrong concurrent session.
-if [[ -z "$_MA_LOOP_DIR" ]] || [[ ! -f "$_MA_LOOP_DIR/methodology-analysis-state.md" ]]; then
+# Only fall back when NO session-matched loop was found (spawned agent case).
+# If the session has its own active loop, do NOT search for another session's
+# methodology analysis -- that would incorrectly restrict the current session.
+if [[ -z "$_MA_LOOP_DIR" ]]; then
     _MA_LOOP_DIR=$(find_methodology_analysis_loop "$LOOP_BASE_DIR")
 fi
 

--- a/hooks/loop-edit-validator.sh
+++ b/hooks/loop-edit-validator.sh
@@ -91,9 +91,10 @@ LOOP_BASE_DIR="${LOOP_BASE_DIR:-$PROJECT_ROOT/.humanize/rlcr}"
 _MA_LOOP_DIR="${LOOP_DIR:-$(find_active_loop "$LOOP_BASE_DIR" "$HOOK_SESSION_ID")}"
 
 # Spawned agents (e.g., Opus analysis agent) have a different session_id.
-# Try unfiltered search to detect methodology analysis phase for them.
-if [[ -z "$_MA_LOOP_DIR" ]]; then
-    _MA_LOOP_DIR=$(find_active_loop "$LOOP_BASE_DIR" "")
+# Use targeted search that scans ALL loops for methodology-analysis-state.md
+# to avoid binding to a wrong concurrent session.
+if [[ -z "$_MA_LOOP_DIR" ]] || [[ ! -f "$_MA_LOOP_DIR/methodology-analysis-state.md" ]]; then
+    _MA_LOOP_DIR=$(find_methodology_analysis_loop "$LOOP_BASE_DIR")
 fi
 
 if [[ -n "$_MA_LOOP_DIR" ]] && [[ -f "$_MA_LOOP_DIR/methodology-analysis-state.md" ]]; then

--- a/hooks/loop-edit-validator.sh
+++ b/hooks/loop-edit-validator.sh
@@ -90,7 +90,8 @@ PROJECT_ROOT="${PROJECT_ROOT:-${CLAUDE_PROJECT_DIR:-$(pwd)}}"
 LOOP_BASE_DIR="${LOOP_BASE_DIR:-$PROJECT_ROOT/.humanize/rlcr}"
 # Use only the session-matched loop. Do NOT fall back to an unfiltered search,
 # as that would incorrectly restrict unrelated sessions opened in the same repo.
-# Spawned agents (with different session_ids) are guided by their prompt instead.
+# Limitation: Spawned agents (different session_id) are not restricted by hooks;
+# their sanitization is enforced by the analysis prompt.
 _MA_LOOP_DIR="${LOOP_DIR:-$(find_active_loop "$LOOP_BASE_DIR" "$HOOK_SESSION_ID")}"
 
 if [[ -n "$_MA_LOOP_DIR" ]] && [[ -f "$_MA_LOOP_DIR/methodology-analysis-state.md" ]]; then

--- a/hooks/loop-read-validator.sh
+++ b/hooks/loop-read-validator.sh
@@ -90,7 +90,12 @@ if [[ -n "$_MA_CHECK_DIR" ]]; then
     _MA_STATE=$(resolve_active_state_file "$_MA_CHECK_DIR")
     if [[ "$_MA_STATE" == *"/methodology-analysis-state.md" ]]; then
         # Canonicalize to prevent path traversal
+        # If realpath fails (file doesn't exist yet on BSD/macOS), resolve parent dir
         _ma_real_path=$(realpath "$FILE_PATH" 2>/dev/null || echo "")
+        if [[ -z "$_ma_real_path" ]]; then
+            _ma_parent=$(realpath "$(dirname "$FILE_PATH")" 2>/dev/null || echo "")
+            [[ -n "$_ma_parent" ]] && _ma_real_path="$_ma_parent/$(basename "$FILE_PATH")"
+        fi
         _ma_real_loop=$(realpath "$_MA_CHECK_DIR" 2>/dev/null || echo "")
         if [[ -n "$_ma_real_path" ]] && [[ -n "$_ma_real_loop" ]] && \
            [[ "$_ma_real_path" == "$_ma_real_loop/"* ]]; then

--- a/hooks/loop-read-validator.sh
+++ b/hooks/loop-read-validator.sh
@@ -66,6 +66,53 @@ if is_round_file_type "$FILE_PATH_LOWER" "todos"; then
 fi
 
 # ========================================
+# Methodology Analysis Phase Read Restriction
+# ========================================
+# During methodology analysis, restrict reads of files within the loop
+# directory to only the artifacts the analysis agent needs. This prevents
+# project-specific information from leaking into the analysis report.
+# Files outside the loop directory are allowed (Claude needs system files).
+# This check MUST come before the summary/prompt early exit below,
+# otherwise non-summary/prompt files in the loop dir escape restriction.
+
+PROJECT_ROOT="${PROJECT_ROOT:-${CLAUDE_PROJECT_DIR:-$(pwd)}}"
+LOOP_BASE_DIR="${LOOP_BASE_DIR:-$PROJECT_ROOT/.humanize/rlcr}"
+ACTIVE_LOOP_DIR="${LOOP_DIR:-$(find_active_loop "$LOOP_BASE_DIR" "$HOOK_SESSION_ID")}"
+
+if [[ -n "$ACTIVE_LOOP_DIR" ]]; then
+    _MA_STATE=$(resolve_active_state_file "$ACTIVE_LOOP_DIR")
+    if [[ "$_MA_STATE" == *"/methodology-analysis-state.md" ]]; then
+        # Canonicalize to prevent path traversal
+        _ma_real_path=$(realpath "$FILE_PATH" 2>/dev/null || echo "")
+        _ma_real_loop=$(realpath "$ACTIVE_LOOP_DIR" 2>/dev/null || echo "")
+        if [[ -n "$_ma_real_path" ]] && [[ -n "$_ma_real_loop" ]] && \
+           [[ "$_ma_real_path" == "$_ma_real_loop/"* ]]; then
+            _ma_basename=$(basename "$_ma_real_path")
+            # Allowlist: only files the analysis agent needs
+            # - round-*-summary.md: development record summaries
+            # - round-*-review-result.md: review feedback
+            # - methodology-analysis-report.md: the agent's own output
+            # - methodology-analysis-done.md: completion marker
+            # - methodology-analysis-state.md: state file (for parsing)
+            case "$_ma_basename" in
+                round-*-summary.md|round-*-review-result.md|methodology-analysis-report.md|methodology-analysis-done.md|methodology-analysis-state.md)
+                    exit 0
+                    ;;
+                *)
+                    echo "# Read Blocked During Methodology Analysis
+
+Only analysis artifacts can be read from the loop directory during this phase.
+Allowed: round-*-summary.md, round-*-review-result.md, methodology-analysis-*.md" >&2
+                    exit 2
+                    ;;
+            esac
+        fi
+        # Files outside loop dir are allowed (Claude needs system files to function)
+        exit 0
+    fi
+fi
+
+# ========================================
 # Check for Round Files (summary/prompt)
 # ========================================
 
@@ -80,9 +127,8 @@ IN_HUMANIZE_LOOP_DIR=$(is_in_humanize_loop_dir "$FILE_PATH" && echo "true" || ec
 # Find Active Loop and Current Round
 # ========================================
 
-PROJECT_ROOT="${PROJECT_ROOT:-${CLAUDE_PROJECT_DIR:-$(pwd)}}"
-LOOP_BASE_DIR="${LOOP_BASE_DIR:-$PROJECT_ROOT/.humanize/rlcr}"
-ACTIVE_LOOP_DIR="${LOOP_DIR:-$(find_active_loop "$LOOP_BASE_DIR" "$HOOK_SESSION_ID")}"
+# Re-use ACTIVE_LOOP_DIR if already set by methodology analysis check above
+ACTIVE_LOOP_DIR="${ACTIVE_LOOP_DIR:-${LOOP_DIR:-$(find_active_loop "$LOOP_BASE_DIR" "$HOOK_SESSION_ID")}}"
 
 if [[ -z "$ACTIVE_LOOP_DIR" ]]; then
     exit 0
@@ -90,29 +136,6 @@ fi
 
 # Detect loop phase from state file
 STATE_FILE_TO_PARSE=$(resolve_active_state_file "$ACTIVE_LOOP_DIR")
-
-# In Methodology Analysis Phase, allow reading specific analysis-related files only
-# The Opus agent needs round summaries, review results, and its own artifacts
-if [[ "$STATE_FILE_TO_PARSE" == *"/methodology-analysis-state.md" ]]; then
-    # Canonicalize to prevent path traversal (e.g., $LOOP_DIR/../secrets)
-    local_real_path=$(realpath "$FILE_PATH" 2>/dev/null || echo "")
-    local_real_loop=$(realpath "$ACTIVE_LOOP_DIR" 2>/dev/null || echo "")
-    if [[ -n "$local_real_path" ]] && [[ -n "$local_real_loop" ]] && \
-       [[ "$local_real_path" == "$local_real_loop/"* ]]; then
-        local_basename=$(basename "$local_real_path")
-        # Allowlist: only files the analysis agent needs
-        # - round-*-summary.md: development record summaries
-        # - round-*-review-result.md: Codex review feedback
-        # - methodology-analysis-report.md: the agent's own output
-        # - methodology-analysis-done.md: completion marker
-        # - methodology-analysis-state.md: state file (for parsing)
-        case "$local_basename" in
-            round-*-summary.md|round-*-review-result.md|methodology-analysis-report.md|methodology-analysis-done.md|methodology-analysis-state.md)
-                exit 0
-                ;;
-        esac
-    fi
-fi
 
 # Parse state file using strict validation (fail closed on malformed state)
 if ! parse_state_file_strict "$STATE_FILE_TO_PARSE" 2>/dev/null; then

--- a/hooks/loop-read-validator.sh
+++ b/hooks/loop-read-validator.sh
@@ -88,8 +88,17 @@ if [[ -z "$ACTIVE_LOOP_DIR" ]]; then
     exit 0
 fi
 
-# Detect if we're in Finalize Phase (finalize-state.md exists)
+# Detect loop phase from state file
 STATE_FILE_TO_PARSE=$(resolve_active_state_file "$ACTIVE_LOOP_DIR")
+
+# In Methodology Analysis Phase, allow reading all round files (summaries and review results)
+# The analysis agent needs access to the full development history
+if [[ "$STATE_FILE_TO_PARSE" == *"/methodology-analysis-state.md" ]]; then
+    # Only allow reads within the active loop directory
+    if [[ "$FILE_PATH" == "$ACTIVE_LOOP_DIR/"* ]]; then
+        exit 0
+    fi
+fi
 
 # Parse state file using strict validation (fail closed on malformed state)
 if ! parse_state_file_strict "$STATE_FILE_TO_PARSE" 2>/dev/null; then

--- a/hooks/loop-read-validator.sh
+++ b/hooks/loop-read-validator.sh
@@ -91,12 +91,26 @@ fi
 # Detect loop phase from state file
 STATE_FILE_TO_PARSE=$(resolve_active_state_file "$ACTIVE_LOOP_DIR")
 
-# In Methodology Analysis Phase, allow reading all round files (summaries and review results)
-# The analysis agent needs access to the full development history
+# In Methodology Analysis Phase, allow reading specific analysis-related files only
+# The Opus agent needs round summaries, review results, and its own artifacts
 if [[ "$STATE_FILE_TO_PARSE" == *"/methodology-analysis-state.md" ]]; then
-    # Only allow reads within the active loop directory
-    if [[ "$FILE_PATH" == "$ACTIVE_LOOP_DIR/"* ]]; then
-        exit 0
+    # Canonicalize to prevent path traversal (e.g., $LOOP_DIR/../secrets)
+    local_real_path=$(realpath "$FILE_PATH" 2>/dev/null || echo "")
+    local_real_loop=$(realpath "$ACTIVE_LOOP_DIR" 2>/dev/null || echo "")
+    if [[ -n "$local_real_path" ]] && [[ -n "$local_real_loop" ]] && \
+       [[ "$local_real_path" == "$local_real_loop/"* ]]; then
+        local_basename=$(basename "$local_real_path")
+        # Allowlist: only files the analysis agent needs
+        # - round-*-summary.md: development record summaries
+        # - round-*-review-result.md: Codex review feedback
+        # - methodology-analysis-report.md: the agent's own output
+        # - methodology-analysis-done.md: completion marker
+        # - methodology-analysis-state.md: state file (for parsing)
+        case "$local_basename" in
+            round-*-summary.md|round-*-review-result.md|methodology-analysis-report.md|methodology-analysis-done.md|methodology-analysis-state.md)
+                exit 0
+                ;;
+        esac
     fi
 fi
 

--- a/hooks/loop-read-validator.sh
+++ b/hooks/loop-read-validator.sh
@@ -119,7 +119,21 @@ Allowed: round-*-summary.md, round-*-review-result.md, methodology-analysis-*.md
                     ;;
             esac
         fi
-        # Files outside loop dir are allowed (Claude needs system files to function)
+        # Files within the project root are blocked (project-specific information)
+        # Files outside the project root are allowed (system files, config, etc.)
+        _ma_project_real=$(realpath "$PROJECT_ROOT" 2>/dev/null || echo "")
+        if [[ -n "$_ma_project_real" ]]; then
+            _ma_path_check="${_ma_real_path:-$FILE_PATH}"
+            if [[ "$_ma_path_check" == "$_ma_project_real/"* ]] || \
+               [[ "$_ma_path_check" == "$PROJECT_ROOT/"* ]]; then
+                echo "# Read Blocked During Methodology Analysis
+
+Reading project files is not allowed during the methodology analysis phase.
+Only analysis artifacts within the loop directory can be read.
+Allowed: round-*-summary.md, round-*-review-result.md, methodology-analysis-*.md" >&2
+                exit 2
+            fi
+        fi
         exit 0
     fi
 fi

--- a/hooks/loop-read-validator.sh
+++ b/hooks/loop-read-validator.sh
@@ -79,12 +79,19 @@ PROJECT_ROOT="${PROJECT_ROOT:-${CLAUDE_PROJECT_DIR:-$(pwd)}}"
 LOOP_BASE_DIR="${LOOP_BASE_DIR:-$PROJECT_ROOT/.humanize/rlcr}"
 ACTIVE_LOOP_DIR="${LOOP_DIR:-$(find_active_loop "$LOOP_BASE_DIR" "$HOOK_SESSION_ID")}"
 
-if [[ -n "$ACTIVE_LOOP_DIR" ]]; then
-    _MA_STATE=$(resolve_active_state_file "$ACTIVE_LOOP_DIR")
+# Spawned agents (e.g., Opus analysis agent) have a different session_id.
+# Try unfiltered search to detect methodology analysis phase for them.
+_MA_CHECK_DIR="$ACTIVE_LOOP_DIR"
+if [[ -z "$_MA_CHECK_DIR" ]]; then
+    _MA_CHECK_DIR=$(find_active_loop "$LOOP_BASE_DIR" "")
+fi
+
+if [[ -n "$_MA_CHECK_DIR" ]]; then
+    _MA_STATE=$(resolve_active_state_file "$_MA_CHECK_DIR")
     if [[ "$_MA_STATE" == *"/methodology-analysis-state.md" ]]; then
         # Canonicalize to prevent path traversal
         _ma_real_path=$(realpath "$FILE_PATH" 2>/dev/null || echo "")
-        _ma_real_loop=$(realpath "$ACTIVE_LOOP_DIR" 2>/dev/null || echo "")
+        _ma_real_loop=$(realpath "$_MA_CHECK_DIR" 2>/dev/null || echo "")
         if [[ -n "$_ma_real_path" ]] && [[ -n "$_ma_real_loop" ]] && \
            [[ "$_ma_real_path" == "$_ma_real_loop/"* ]]; then
             _ma_basename=$(basename "$_ma_real_path")

--- a/hooks/loop-read-validator.sh
+++ b/hooks/loop-read-validator.sh
@@ -79,7 +79,8 @@ PROJECT_ROOT="${PROJECT_ROOT:-${CLAUDE_PROJECT_DIR:-$(pwd)}}"
 LOOP_BASE_DIR="${LOOP_BASE_DIR:-$PROJECT_ROOT/.humanize/rlcr}"
 # Use only the session-matched loop. Do NOT fall back to an unfiltered search,
 # as that would incorrectly restrict unrelated sessions opened in the same repo.
-# Spawned agents (with different session_ids) are guided by their prompt instead.
+# Limitation: Spawned agents (different session_id) are not restricted by hooks;
+# their sanitization is enforced by the analysis prompt.
 ACTIVE_LOOP_DIR="${LOOP_DIR:-$(find_active_loop "$LOOP_BASE_DIR" "$HOOK_SESSION_ID")}"
 _MA_CHECK_DIR="$ACTIVE_LOOP_DIR"
 

--- a/hooks/loop-read-validator.sh
+++ b/hooks/loop-read-validator.sh
@@ -100,14 +100,15 @@ if [[ -n "$_MA_CHECK_DIR" ]]; then
         [[ -z "$_ma_real_loop" ]] && _ma_real_loop="$_MA_CHECK_DIR"
         if [[ "$_ma_real_path" == "$_ma_real_loop/"* ]]; then
             _ma_basename=$(basename "$_ma_real_path")
-            # Allowlist: only files the analysis agent needs
-            # - round-*-summary.md: development record summaries
-            # - round-*-review-result.md: review feedback
-            # - methodology-analysis-report.md: the agent's own output
-            # - methodology-analysis-done.md: completion marker
-            # - methodology-analysis-state.md: state file (for parsing)
+            # Allowlist: only methodology artifacts (not raw development records).
+            # Raw records (round-*-summary.md, round-*-review-result.md) are
+            # intentionally excluded so the originating session cannot read
+            # project-specific content and must rely solely on the sanitized
+            # methodology-analysis-report.md for all user-facing output.
+            # The spawned Opus agent reads raw records directly (not restricted
+            # by hooks due to different session_id -- see limitation comment above).
             case "$_ma_basename" in
-                round-*-summary.md|round-*-review-result.md|methodology-analysis-report.md|methodology-analysis-done.md|methodology-analysis-state.md)
+                methodology-analysis-report.md|methodology-analysis-done.md|methodology-analysis-state.md)
                     exit 0
                     ;;
                 *)

--- a/hooks/loop-read-validator.sh
+++ b/hooks/loop-read-validator.sh
@@ -114,8 +114,8 @@ if [[ -n "$_MA_CHECK_DIR" ]]; then
                 *)
                     echo "# Read Blocked During Methodology Analysis
 
-Only analysis artifacts can be read from the loop directory during this phase.
-Allowed: round-*-summary.md, round-*-review-result.md, methodology-analysis-*.md" >&2
+Only methodology artifacts can be read from the loop directory during this phase.
+Allowed: methodology-analysis-report.md, methodology-analysis-done.md, methodology-analysis-state.md" >&2
                     exit 2
                     ;;
             esac
@@ -130,8 +130,8 @@ Allowed: round-*-summary.md, round-*-review-result.md, methodology-analysis-*.md
                 echo "# Read Blocked During Methodology Analysis
 
 Reading project files is not allowed during the methodology analysis phase.
-Only analysis artifacts within the loop directory can be read.
-Allowed: round-*-summary.md, round-*-review-result.md, methodology-analysis-*.md" >&2
+Only methodology artifacts within the loop directory can be read.
+Allowed: methodology-analysis-report.md, methodology-analysis-done.md, methodology-analysis-state.md" >&2
                 exit 2
             fi
         fi

--- a/hooks/loop-read-validator.sh
+++ b/hooks/loop-read-validator.sh
@@ -77,15 +77,11 @@ fi
 
 PROJECT_ROOT="${PROJECT_ROOT:-${CLAUDE_PROJECT_DIR:-$(pwd)}}"
 LOOP_BASE_DIR="${LOOP_BASE_DIR:-$PROJECT_ROOT/.humanize/rlcr}"
+# Use only the session-matched loop. Do NOT fall back to an unfiltered search,
+# as that would incorrectly restrict unrelated sessions opened in the same repo.
+# Spawned agents (with different session_ids) are guided by their prompt instead.
 ACTIVE_LOOP_DIR="${LOOP_DIR:-$(find_active_loop "$LOOP_BASE_DIR" "$HOOK_SESSION_ID")}"
-
-# Only fall back when NO session-matched loop was found (spawned agent case).
-# If the session has its own active loop, do NOT search for another session's
-# methodology analysis -- that would incorrectly restrict the current session.
 _MA_CHECK_DIR="$ACTIVE_LOOP_DIR"
-if [[ -z "$_MA_CHECK_DIR" ]]; then
-    _MA_CHECK_DIR=$(find_methodology_analysis_loop "$LOOP_BASE_DIR")
-fi
 
 if [[ -n "$_MA_CHECK_DIR" ]]; then
     _MA_STATE=$(resolve_active_state_file "$_MA_CHECK_DIR")
@@ -98,8 +94,10 @@ if [[ -n "$_MA_CHECK_DIR" ]]; then
             [[ -n "$_ma_parent" ]] && _ma_real_path="$_ma_parent/$(basename "$FILE_PATH")"
         fi
         _ma_real_loop=$(realpath "$_MA_CHECK_DIR" 2>/dev/null || echo "")
-        if [[ -n "$_ma_real_path" ]] && [[ -n "$_ma_real_loop" ]] && \
-           [[ "$_ma_real_path" == "$_ma_real_loop/"* ]]; then
+        # Fallback to raw paths when realpath is unavailable (older macOS/BSD)
+        [[ -z "$_ma_real_path" ]] && _ma_real_path="$FILE_PATH"
+        [[ -z "$_ma_real_loop" ]] && _ma_real_loop="$_MA_CHECK_DIR"
+        if [[ "$_ma_real_path" == "$_ma_real_loop/"* ]]; then
             _ma_basename=$(basename "$_ma_real_path")
             # Allowlist: only files the analysis agent needs
             # - round-*-summary.md: development record summaries
@@ -122,7 +120,7 @@ Allowed: round-*-summary.md, round-*-review-result.md, methodology-analysis-*.md
         fi
         # Files within the project root are blocked (project-specific information)
         # Files outside the project root are allowed (system files, config, etc.)
-        _ma_project_real=$(realpath "$PROJECT_ROOT" 2>/dev/null || echo "")
+        _ma_project_real=$(realpath "$PROJECT_ROOT" 2>/dev/null || echo "$PROJECT_ROOT")
         if [[ -n "$_ma_project_real" ]]; then
             _ma_path_check="${_ma_real_path:-$FILE_PATH}"
             if [[ "$_ma_path_check" == "$_ma_project_real/"* ]] || \

--- a/hooks/loop-read-validator.sh
+++ b/hooks/loop-read-validator.sh
@@ -80,10 +80,11 @@ LOOP_BASE_DIR="${LOOP_BASE_DIR:-$PROJECT_ROOT/.humanize/rlcr}"
 ACTIVE_LOOP_DIR="${LOOP_DIR:-$(find_active_loop "$LOOP_BASE_DIR" "$HOOK_SESSION_ID")}"
 
 # Spawned agents (e.g., Opus analysis agent) have a different session_id.
-# Try unfiltered search to detect methodology analysis phase for them.
+# Use targeted search that scans ALL loops for methodology-analysis-state.md
+# to avoid binding to a wrong concurrent session.
 _MA_CHECK_DIR="$ACTIVE_LOOP_DIR"
-if [[ -z "$_MA_CHECK_DIR" ]]; then
-    _MA_CHECK_DIR=$(find_active_loop "$LOOP_BASE_DIR" "")
+if [[ -z "$_MA_CHECK_DIR" ]] || [[ ! -f "$_MA_CHECK_DIR/methodology-analysis-state.md" ]]; then
+    _MA_CHECK_DIR=$(find_methodology_analysis_loop "$LOOP_BASE_DIR")
 fi
 
 if [[ -n "$_MA_CHECK_DIR" ]]; then

--- a/hooks/loop-read-validator.sh
+++ b/hooks/loop-read-validator.sh
@@ -79,11 +79,11 @@ PROJECT_ROOT="${PROJECT_ROOT:-${CLAUDE_PROJECT_DIR:-$(pwd)}}"
 LOOP_BASE_DIR="${LOOP_BASE_DIR:-$PROJECT_ROOT/.humanize/rlcr}"
 ACTIVE_LOOP_DIR="${LOOP_DIR:-$(find_active_loop "$LOOP_BASE_DIR" "$HOOK_SESSION_ID")}"
 
-# Spawned agents (e.g., Opus analysis agent) have a different session_id.
-# Use targeted search that scans ALL loops for methodology-analysis-state.md
-# to avoid binding to a wrong concurrent session.
+# Only fall back when NO session-matched loop was found (spawned agent case).
+# If the session has its own active loop, do NOT search for another session's
+# methodology analysis -- that would incorrectly restrict the current session.
 _MA_CHECK_DIR="$ACTIVE_LOOP_DIR"
-if [[ -z "$_MA_CHECK_DIR" ]] || [[ ! -f "$_MA_CHECK_DIR/methodology-analysis-state.md" ]]; then
+if [[ -z "$_MA_CHECK_DIR" ]]; then
     _MA_CHECK_DIR=$(find_methodology_analysis_loop "$LOOP_BASE_DIR")
 fi
 

--- a/hooks/loop-write-validator.sh
+++ b/hooks/loop-write-validator.sh
@@ -97,6 +97,36 @@ if [[ "$IN_PR_LOOP_DIR" == "true" ]]; then
 fi
 
 # ========================================
+# Methodology Analysis Phase Write Restriction
+# ========================================
+# During methodology analysis, only methodology artifacts can be written.
+# This prevents source code modifications after Codex has signed off.
+# This check MUST come before the file type early exits below.
+
+PROJECT_ROOT="${PROJECT_ROOT:-${CLAUDE_PROJECT_DIR:-$(pwd)}}"
+LOOP_BASE_DIR="${LOOP_BASE_DIR:-$PROJECT_ROOT/.humanize/rlcr}"
+_MA_LOOP_DIR="${LOOP_DIR:-$(find_active_loop "$LOOP_BASE_DIR" "$HOOK_SESSION_ID")}"
+
+if [[ -n "$_MA_LOOP_DIR" ]] && [[ -f "$_MA_LOOP_DIR/methodology-analysis-state.md" ]]; then
+    _ma_real_path=$(realpath "$FILE_PATH" 2>/dev/null || echo "")
+    _ma_real_loop=$(realpath "$_MA_LOOP_DIR" 2>/dev/null || echo "")
+    if [[ -n "$_ma_real_path" ]] && [[ -n "$_ma_real_loop" ]] && \
+       [[ "$_ma_real_path" == "$_ma_real_loop/"* ]]; then
+        _ma_basename=$(basename "$_ma_real_path")
+        case "$_ma_basename" in
+            methodology-analysis-report.md|methodology-analysis-done.md)
+                exit 0
+                ;;
+        esac
+    fi
+    echo "# Write Blocked During Methodology Analysis
+
+During the methodology analysis phase, only methodology artifacts can be written.
+Allowed: methodology-analysis-report.md, methodology-analysis-done.md" >&2
+    exit 2
+fi
+
+# ========================================
 # Determine File Types
 # ========================================
 

--- a/hooks/loop-write-validator.sh
+++ b/hooks/loop-write-validator.sh
@@ -114,7 +114,12 @@ if [[ -z "$_MA_LOOP_DIR" ]]; then
 fi
 
 if [[ -n "$_MA_LOOP_DIR" ]] && [[ -f "$_MA_LOOP_DIR/methodology-analysis-state.md" ]]; then
+    # If realpath fails (file doesn't exist yet on BSD/macOS), resolve parent dir
     _ma_real_path=$(realpath "$FILE_PATH" 2>/dev/null || echo "")
+    if [[ -z "$_ma_real_path" ]]; then
+        _ma_parent=$(realpath "$(dirname "$FILE_PATH")" 2>/dev/null || echo "")
+        [[ -n "$_ma_parent" ]] && _ma_real_path="$_ma_parent/$(basename "$FILE_PATH")"
+    fi
     _ma_real_loop=$(realpath "$_MA_LOOP_DIR" 2>/dev/null || echo "")
     if [[ -n "$_ma_real_path" ]] && [[ -n "$_ma_real_loop" ]] && \
        [[ "$_ma_real_path" == "$_ma_real_loop/"* ]]; then

--- a/hooks/loop-write-validator.sh
+++ b/hooks/loop-write-validator.sh
@@ -107,7 +107,8 @@ PROJECT_ROOT="${PROJECT_ROOT:-${CLAUDE_PROJECT_DIR:-$(pwd)}}"
 LOOP_BASE_DIR="${LOOP_BASE_DIR:-$PROJECT_ROOT/.humanize/rlcr}"
 # Use only the session-matched loop. Do NOT fall back to an unfiltered search,
 # as that would incorrectly restrict unrelated sessions opened in the same repo.
-# Spawned agents (with different session_ids) are guided by their prompt instead.
+# Limitation: Spawned agents (different session_id) are not restricted by hooks;
+# their sanitization is enforced by the analysis prompt.
 _MA_LOOP_DIR="${LOOP_DIR:-$(find_active_loop "$LOOP_BASE_DIR" "$HOOK_SESSION_ID")}"
 
 if [[ -n "$_MA_LOOP_DIR" ]] && [[ -f "$_MA_LOOP_DIR/methodology-analysis-state.md" ]]; then

--- a/hooks/loop-write-validator.sh
+++ b/hooks/loop-write-validator.sh
@@ -107,10 +107,10 @@ PROJECT_ROOT="${PROJECT_ROOT:-${CLAUDE_PROJECT_DIR:-$(pwd)}}"
 LOOP_BASE_DIR="${LOOP_BASE_DIR:-$PROJECT_ROOT/.humanize/rlcr}"
 _MA_LOOP_DIR="${LOOP_DIR:-$(find_active_loop "$LOOP_BASE_DIR" "$HOOK_SESSION_ID")}"
 
-# Spawned agents (e.g., Opus analysis agent) have a different session_id.
-# Use targeted search that scans ALL loops for methodology-analysis-state.md
-# to avoid binding to a wrong concurrent session.
-if [[ -z "$_MA_LOOP_DIR" ]] || [[ ! -f "$_MA_LOOP_DIR/methodology-analysis-state.md" ]]; then
+# Only fall back when NO session-matched loop was found (spawned agent case).
+# If the session has its own active loop, do NOT search for another session's
+# methodology analysis -- that would incorrectly restrict the current session.
+if [[ -z "$_MA_LOOP_DIR" ]]; then
     _MA_LOOP_DIR=$(find_methodology_analysis_loop "$LOOP_BASE_DIR")
 fi
 

--- a/hooks/loop-write-validator.sh
+++ b/hooks/loop-write-validator.sh
@@ -109,12 +109,12 @@ if [[ "$IS_SUMMARY_FILE" == "false" ]] && [[ "$IS_FINALIZE_SUMMARY" == "false" ]
     exit 0
 fi
 
-# For state.md, finalize-state.md, goal-tracker.md, and plan.md in .humanize/rlcr, we need further validation
+# For state.md, finalize-state.md, methodology-analysis-state.md, goal-tracker.md, and plan.md in .humanize/rlcr, we need further validation
 # For other files in .humanize/rlcr that aren't summaries, allow them
 FILENAME=$(basename "$FILE_PATH")
 IS_PLAN_BACKUP=$([[ "$FILENAME" == "plan.md" ]] && echo "true" || echo "false")
 if [[ "$IN_HUMANIZE_LOOP_DIR" == "true" ]] && [[ "$IS_SUMMARY_FILE" == "false" ]] && [[ "$IS_FINALIZE_SUMMARY" == "false" ]]; then
-    if ! is_state_file_path "$FILE_PATH_LOWER" && ! is_finalize_state_file_path "$FILE_PATH_LOWER" && ! is_goal_tracker_path "$FILE_PATH_LOWER" && [[ "$IS_PLAN_BACKUP" != "true" ]]; then
+    if ! is_state_file_path "$FILE_PATH_LOWER" && ! is_finalize_state_file_path "$FILE_PATH_LOWER" && ! is_methodology_analysis_state_file_path "$FILE_PATH_LOWER" && ! is_goal_tracker_path "$FILE_PATH_LOWER" && [[ "$IS_PLAN_BACKUP" != "true" ]]; then
         exit 0
     fi
 fi
@@ -147,9 +147,14 @@ fi
 CURRENT_ROUND="$STATE_CURRENT_ROUND"
 
 # ========================================
-# Block State File Writes (state.md and finalize-state.md)
+# Block State File Writes (state.md, finalize-state.md, methodology-analysis-state.md)
 # ========================================
-# NOTE: Check finalize-state.md FIRST because is_state_file_path also matches finalize-state.md
+# NOTE: Check most specific patterns first because is_state_file_path matches any *state.md
+
+if is_methodology_analysis_state_file_path "$FILE_PATH_LOWER"; then
+    methodology_analysis_state_file_blocked_message >&2
+    exit 2
+fi
 
 if is_finalize_state_file_path "$FILE_PATH_LOWER"; then
     finalize_state_file_blocked_message >&2

--- a/hooks/loop-write-validator.sh
+++ b/hooks/loop-write-validator.sh
@@ -105,14 +105,10 @@ fi
 
 PROJECT_ROOT="${PROJECT_ROOT:-${CLAUDE_PROJECT_DIR:-$(pwd)}}"
 LOOP_BASE_DIR="${LOOP_BASE_DIR:-$PROJECT_ROOT/.humanize/rlcr}"
+# Use only the session-matched loop. Do NOT fall back to an unfiltered search,
+# as that would incorrectly restrict unrelated sessions opened in the same repo.
+# Spawned agents (with different session_ids) are guided by their prompt instead.
 _MA_LOOP_DIR="${LOOP_DIR:-$(find_active_loop "$LOOP_BASE_DIR" "$HOOK_SESSION_ID")}"
-
-# Only fall back when NO session-matched loop was found (spawned agent case).
-# If the session has its own active loop, do NOT search for another session's
-# methodology analysis -- that would incorrectly restrict the current session.
-if [[ -z "$_MA_LOOP_DIR" ]]; then
-    _MA_LOOP_DIR=$(find_methodology_analysis_loop "$LOOP_BASE_DIR")
-fi
 
 if [[ -n "$_MA_LOOP_DIR" ]] && [[ -f "$_MA_LOOP_DIR/methodology-analysis-state.md" ]]; then
     # If realpath fails (file doesn't exist yet on BSD/macOS), resolve parent dir
@@ -122,8 +118,10 @@ if [[ -n "$_MA_LOOP_DIR" ]] && [[ -f "$_MA_LOOP_DIR/methodology-analysis-state.m
         [[ -n "$_ma_parent" ]] && _ma_real_path="$_ma_parent/$(basename "$FILE_PATH")"
     fi
     _ma_real_loop=$(realpath "$_MA_LOOP_DIR" 2>/dev/null || echo "")
-    if [[ -n "$_ma_real_path" ]] && [[ -n "$_ma_real_loop" ]] && \
-       [[ "$_ma_real_path" == "$_ma_real_loop/"* ]]; then
+    # Fallback to raw paths when realpath is unavailable (older macOS/BSD)
+    [[ -z "$_ma_real_path" ]] && _ma_real_path="$FILE_PATH"
+    [[ -z "$_ma_real_loop" ]] && _ma_real_loop="$_MA_LOOP_DIR"
+    if [[ "$_ma_real_path" == "$_ma_real_loop/"* ]]; then
         _ma_basename=$(basename "$_ma_real_path")
         case "$_ma_basename" in
             methodology-analysis-report.md|methodology-analysis-done.md)

--- a/hooks/loop-write-validator.sh
+++ b/hooks/loop-write-validator.sh
@@ -108,12 +108,10 @@ LOOP_BASE_DIR="${LOOP_BASE_DIR:-$PROJECT_ROOT/.humanize/rlcr}"
 _MA_LOOP_DIR="${LOOP_DIR:-$(find_active_loop "$LOOP_BASE_DIR" "$HOOK_SESSION_ID")}"
 
 # Spawned agents (e.g., Opus analysis agent) have a different session_id.
-# Try unfiltered search to detect methodology analysis phase for them.
-# Note: This may briefly affect concurrent sessions in the same repo, but
-# methodology analysis is short-lived and this ensures spawned agents
-# cannot bypass the write freeze after Codex has signed off.
-if [[ -z "$_MA_LOOP_DIR" ]]; then
-    _MA_LOOP_DIR=$(find_active_loop "$LOOP_BASE_DIR" "")
+# Use targeted search that scans ALL loops for methodology-analysis-state.md
+# to avoid binding to a wrong concurrent session.
+if [[ -z "$_MA_LOOP_DIR" ]] || [[ ! -f "$_MA_LOOP_DIR/methodology-analysis-state.md" ]]; then
+    _MA_LOOP_DIR=$(find_methodology_analysis_loop "$LOOP_BASE_DIR")
 fi
 
 if [[ -n "$_MA_LOOP_DIR" ]] && [[ -f "$_MA_LOOP_DIR/methodology-analysis-state.md" ]]; then

--- a/hooks/loop-write-validator.sh
+++ b/hooks/loop-write-validator.sh
@@ -107,6 +107,12 @@ PROJECT_ROOT="${PROJECT_ROOT:-${CLAUDE_PROJECT_DIR:-$(pwd)}}"
 LOOP_BASE_DIR="${LOOP_BASE_DIR:-$PROJECT_ROOT/.humanize/rlcr}"
 _MA_LOOP_DIR="${LOOP_DIR:-$(find_active_loop "$LOOP_BASE_DIR" "$HOOK_SESSION_ID")}"
 
+# Spawned agents (e.g., Opus analysis agent) have a different session_id.
+# Try unfiltered search to detect methodology analysis phase for them.
+if [[ -z "$_MA_LOOP_DIR" ]]; then
+    _MA_LOOP_DIR=$(find_active_loop "$LOOP_BASE_DIR" "")
+fi
+
 if [[ -n "$_MA_LOOP_DIR" ]] && [[ -f "$_MA_LOOP_DIR/methodology-analysis-state.md" ]]; then
     _ma_real_path=$(realpath "$FILE_PATH" 2>/dev/null || echo "")
     _ma_real_loop=$(realpath "$_MA_LOOP_DIR" 2>/dev/null || echo "")

--- a/hooks/loop-write-validator.sh
+++ b/hooks/loop-write-validator.sh
@@ -109,6 +109,9 @@ _MA_LOOP_DIR="${LOOP_DIR:-$(find_active_loop "$LOOP_BASE_DIR" "$HOOK_SESSION_ID"
 
 # Spawned agents (e.g., Opus analysis agent) have a different session_id.
 # Try unfiltered search to detect methodology analysis phase for them.
+# Note: This may briefly affect concurrent sessions in the same repo, but
+# methodology analysis is short-lived and this ensures spawned agents
+# cannot bypass the write freeze after Codex has signed off.
 if [[ -z "$_MA_LOOP_DIR" ]]; then
     _MA_LOOP_DIR=$(find_active_loop "$LOOP_BASE_DIR" "")
 fi

--- a/prompt-template/block/methodology-analysis-state-file-modification.md
+++ b/prompt-template/block/methodology-analysis-state-file-modification.md
@@ -1,0 +1,9 @@
+# Methodology Analysis State File Modification Blocked
+
+You cannot modify `methodology-analysis-state.md`. This file is managed by the loop system during the Methodology Analysis Phase.
+
+The Methodology Analysis Phase runs before the loop fully exits. Focus on:
+1. Spawning an Opus agent to analyze development records
+2. Reviewing the sanitized analysis report
+3. Optionally helping the user file a GitHub issue with improvement suggestions
+4. Writing your completion marker to `methodology-analysis-done.md`

--- a/prompt-template/claude/methodology-analysis-prompt.md
+++ b/prompt-template/claude/methodology-analysis-prompt.md
@@ -1,0 +1,73 @@
+# Methodology Analysis Phase
+
+The RLCR loop has reached its exit point.
+
+**Exit reason**: {{EXIT_REASON}} - {{EXIT_REASON_DESCRIPTION}}
+**Rounds completed**: {{CURRENT_ROUND}} of {{MAX_ITERATIONS}}
+
+Before the loop fully exits, please perform a methodology improvement analysis. This analysis helps improve the Humanize development methodology itself -- it is NOT about the project you just worked on.
+
+## Instructions
+
+### 1. Spawn an Opus Agent for Sanitized Analysis
+
+Use the Agent tool with `model: "opus"` to spawn an analysis agent. Give it this task:
+
+**Agent prompt**: Read the development records in `{{LOOP_DIR}}`:
+- All files matching `round-*-summary.md`
+- All files matching `round-*-review-result.md`
+
+Analyze these records from a **pure methodology perspective** and write your findings to `{{LOOP_DIR}}/methodology-analysis-report.md`.
+
+**CRITICAL SANITIZATION RULES** - The report MUST NOT contain:
+- File paths, directory paths, or module paths
+- Function names, variable names, class names, or method names
+- Branch names, commit hashes, or git identifiers
+- Business domain terms, product names, or feature names
+- Code snippets or code fragments of any kind
+- Raw error messages or stack traces
+- Project-specific URLs or endpoints
+- Any information that could identify the specific project
+
+**Focus areas for analysis**:
+- Iteration efficiency: Were rounds productive or did they repeat similar work?
+- Feedback loop quality: Did reviewer feedback lead to meaningful improvements?
+- Stagnation patterns: Were there signs of going in circles?
+- Review effectiveness: Did reviews catch real issues or create false positives?
+- Plan-to-execution alignment: Did execution follow the plan or drift?
+- Round count vs. progress ratio: Was the number of rounds proportional to progress?
+- Communication clarity: Were summaries and reviews clear and actionable?
+
+**Output format**: Write a structured report with methodology improvement suggestions. Each suggestion should describe a general pattern observed and a concrete improvement to the RLCR methodology. If no improvements are found, write a brief note saying the methodology worked well for this session.
+
+### 2. Read the Analysis Report
+
+After the agent completes, read `{{LOOP_DIR}}/methodology-analysis-report.md`. ALL subsequent user-facing content MUST be derived solely from this report -- do NOT reference raw development records directly.
+
+### 3. Handle Results
+
+**If no improvements found**: Briefly inform the user that the methodology analysis found no significant improvement suggestions. Then write a completion note to `{{LOOP_DIR}}/methodology-analysis-done.md` and exit.
+
+**If improvements found**:
+
+a) Report to the user:
+   - Brief summary of the exit reason ({{EXIT_REASON}}: {{EXIT_REASON_DESCRIPTION}})
+   - Methodology improvement suggestions from the report
+
+b) Use `AskUserQuestion` to ask if the user would like to help improve Humanize by opening a GitHub issue with these suggestions. Emphasize:
+   - This is completely voluntary
+   - The content is fully sanitized (no project-specific information)
+   - It helps improve the methodology for everyone
+
+c) **If user declines**: Thank them, write completion marker to `{{LOOP_DIR}}/methodology-analysis-done.md`, and exit.
+
+d) **If user agrees**:
+   - Draft a GitHub issue title and body from the analysis report
+   - Show the draft via a second `AskUserQuestion` for the user to review and confirm
+   - If confirmed: run `gh issue create --repo humania-org/humanize --title "..." --body "..."`
+   - If `gh` is not available, provide the title and body so the user can create the issue manually
+   - Write completion marker to `{{LOOP_DIR}}/methodology-analysis-done.md` and exit
+
+### 4. Completion Marker
+
+You MUST write meaningful content to `{{LOOP_DIR}}/methodology-analysis-done.md` before exiting. This file signals that the analysis phase is complete. A brief summary of what was done (e.g., "Analysis complete, no suggestions" or "Analysis complete, issue filed") is sufficient.

--- a/scripts/cancel-rlcr-loop.sh
+++ b/scripts/cancel-rlcr-loop.sh
@@ -50,7 +50,7 @@ DESCRIPTION:
   Cancels the active RLCR loop by:
   1. Finding the most recent loop directory
   2. Creating a .cancel-requested signal file
-  3. Renaming state.md or finalize-state.md to cancel-state.md
+  3. Renaming state.md, methodology-analysis-state.md, or finalize-state.md to cancel-state.md
 HELP_EOF
             exit 0
             ;;
@@ -98,11 +98,15 @@ fi
 
 STATE_FILE="$LOOP_DIR/state.md"
 FINALIZE_STATE_FILE="$LOOP_DIR/finalize-state.md"
+METHODOLOGY_ANALYSIS_STATE_FILE="$LOOP_DIR/methodology-analysis-state.md"
 CANCEL_SIGNAL="$LOOP_DIR/.cancel-requested"
 
 if [[ -f "$STATE_FILE" ]]; then
     LOOP_STATE="NORMAL_LOOP"
     ACTIVE_STATE_FILE="$STATE_FILE"
+elif [[ -f "$METHODOLOGY_ANALYSIS_STATE_FILE" ]]; then
+    LOOP_STATE="METHODOLOGY_ANALYSIS_PHASE"
+    ACTIVE_STATE_FILE="$METHODOLOGY_ANALYSIS_STATE_FILE"
 elif [[ -f "$FINALIZE_STATE_FILE" ]]; then
     LOOP_STATE="FINALIZE_PHASE"
     ACTIVE_STATE_FILE="$FINALIZE_STATE_FILE"
@@ -151,6 +155,9 @@ touch "$CANCEL_SIGNAL"
 # Clean up any pending session_id signal file (setup may not have completed)
 rm -f "$PROJECT_ROOT/.humanize/.pending-session-id"
 
+# Clean up methodology analysis marker files if present
+rm -f "$LOOP_DIR/.methodology-exit-reason"
+
 # Rename state file to cancel-state.md
 mv "$ACTIVE_STATE_FILE" "$LOOP_DIR/cancel-state.md"
 
@@ -161,6 +168,10 @@ mv "$ACTIVE_STATE_FILE" "$LOOP_DIR/cancel-state.md"
 if [[ "$LOOP_STATE" == "NORMAL_LOOP" ]]; then
     echo "CANCELLED"
     echo "Cancelled RLCR loop (was at round $CURRENT_ROUND of $MAX_ITERATIONS)."
+    echo "State preserved as cancel-state.md"
+elif [[ "$LOOP_STATE" == "METHODOLOGY_ANALYSIS_PHASE" ]]; then
+    echo "CANCELLED_METHODOLOGY_ANALYSIS"
+    echo "Cancelled RLCR loop during Methodology Analysis Phase (was at round $CURRENT_ROUND of $MAX_ITERATIONS)."
     echo "State preserved as cancel-state.md"
 else
     echo "CANCELLED_FINALIZE"

--- a/scripts/lib/monitor-common.sh
+++ b/scripts/lib/monitor-common.sh
@@ -130,7 +130,7 @@ monitor_restore_terminal() {
 monitor_get_status_color() {
     local status="$1"
     case "$status" in
-        active) echo "\033[1;32m" ;;  # green
+        active|methodology-analysis) echo "\033[1;32m" ;;  # green
         completed) echo "\033[1;36m" ;;  # cyan
         failed|error|timeout) echo "\033[1;31m" ;;  # red
         cancelled) echo "\033[1;33m" ;;  # yellow

--- a/scripts/lib/monitor-common.sh
+++ b/scripts/lib/monitor-common.sh
@@ -159,7 +159,11 @@ monitor_find_state_file() {
         return
     fi
 
-    # Priority 1: state.md indicates active loop
+    # Priority 1: Active state files indicate running loop
+    if [[ -f "$session_dir/methodology-analysis-state.md" ]]; then
+        echo "$session_dir/methodology-analysis-state.md|methodology-analysis"
+        return
+    fi
     if [[ -f "$session_dir/state.md" ]]; then
         echo "$session_dir/state.md|active"
         return

--- a/scripts/setup-rlcr-loop.sh
+++ b/scripts/setup-rlcr-loop.sh
@@ -51,6 +51,7 @@ SKIP_IMPL_NO_PLAN="false"
 ASK_CODEX_QUESTION="true"
 AGENT_TEAMS="false"
 BITLESSON_ALLOW_EMPTY_NONE="true"
+PRIVACY_MODE="false"
 
 show_help() {
     cat <<HELP_EOF
@@ -93,6 +94,7 @@ OPTIONS:
                        Allow BitLesson delta with action:none even with no new entries (default)
   --require-bitlesson-entry-for-none
                        Require at least one BitLesson entry when action is none
+  --privacy            Disable methodology analysis at loop exit (default: analysis enabled)
   -h, --help           Show this help message
 
 DESCRIPTION:
@@ -241,6 +243,10 @@ while [[ $# -gt 0 ]]; do
             ;;
         --require-bitlesson-entry-for-none)
             BITLESSON_ALLOW_EMPTY_NONE="false"
+            shift
+            ;;
+        --privacy)
+            PRIVACY_MODE="true"
             shift
             ;;
         -*)
@@ -840,6 +846,7 @@ review_started: $INITIAL_REVIEW_STARTED
 ask_codex_question: $ASK_CODEX_QUESTION
 session_id:
 agent_teams: $AGENT_TEAMS
+privacy_mode: $PRIVACY_MODE
 bitlesson_required: $BITLESSON_STATE_VALUE
 bitlesson_file: $BITLESSON_FILE_REL
 bitlesson_allow_empty_none: $BITLESSON_ALLOW_EMPTY_NONE

--- a/scripts/statusline.sh
+++ b/scripts/statusline.sh
@@ -37,7 +37,9 @@ format_duration() {
 _resolve_rlcr_display() {
     local session_dir="$1"
 
-    if [[ -f "$session_dir/finalize-state.md" ]]; then
+    if [[ -f "$session_dir/methodology-analysis-state.md" ]]; then
+        echo "Analyzing"
+    elif [[ -f "$session_dir/finalize-state.md" ]]; then
         echo "Finalizing"
     elif [[ -f "$session_dir/state.md" ]]; then
         echo "Active"
@@ -95,7 +97,9 @@ get_rlcr_status() {
             [[ -z "$dir" ]] && continue
             local trimmed="${dir%/}"
             local any_state=""
-            if [[ -f "$trimmed/finalize-state.md" ]]; then
+            if [[ -f "$trimmed/methodology-analysis-state.md" ]]; then
+                any_state="$trimmed/methodology-analysis-state.md"
+            elif [[ -f "$trimmed/finalize-state.md" ]]; then
                 any_state="$trimmed/finalize-state.md"
             elif [[ -f "$trimmed/state.md" ]]; then
                 any_state="$trimmed/state.md"

--- a/skills/humanize/SKILL.md
+++ b/skills/humanize/SKILL.md
@@ -96,6 +96,7 @@ Transforms a rough draft document into a structured implementation plan with:
 - `--push-every-round` - Require git push after each round
 - `--claude-answer-codex` - Let Claude answer Codex Open Questions directly (default is AskUserQuestion)
 - `--agent-teams` - Enable Agent Teams mode
+- `--privacy` - Disable methodology analysis at loop exit (default: analysis enabled)
 
 ### Cancel RLCR Loop
 
@@ -226,6 +227,9 @@ Humanize stores all data in `.humanize/`:
 │       ├── round-N-review-result.md
 │       ├── finalize-state.md
 │       ├── finalize-summary.md
+│       ├── methodology-analysis-state.md
+│       ├── methodology-analysis-report.md
+│       ├── methodology-analysis-done.md
 │       └── complete-state.md
 ├── pr-loop/        # PR loop data
 │   └── <timestamp>/


### PR DESCRIPTION
## Summary
- Add a pre-exit methodology analysis phase that runs before the RLCR loop fully exits (on COMPLETE, STOP, or MAXITER)
- An independent Opus agent analyzes development records from a pure methodology perspective, sanitized of project-specific information
- Optionally helps the user file a GitHub issue on the Humanize repo with improvement suggestions
- Feature is ON by default; disable with `--privacy` flag on loop start
- Comprehensive validator enforcement across Read/Write/Edit/Bash hooks during the analysis phase
- Monitor and statusline correctly display "Analyzing" status during the phase

## Changes
- **New files**: `hooks/lib/methodology-analysis.sh`, `prompt-template/claude/methodology-analysis-prompt.md`
- **Modified hooks**: All 4 validators (read/write/edit/bash) enforce methodology analysis restrictions on the originating session
- **Stop hook**: Intercepts 3 exit paths (complete/stop/maxiter), enters methodology analysis phase, handles completion
- **Setup/Cancel**: `--privacy` flag support, cancel during methodology analysis phase
- **Monitor/Statusline**: Methodology analysis shown as active "Analyzing" phase with green status color

## Test plan
- [ ] Start loop with `--privacy`, verify all 3 exit paths skip methodology analysis
- [ ] Complete a loop without `--privacy`, verify methodology analysis phase is entered after finalize
- [ ] Cancel during methodology analysis phase, verify clean cancellation
- [ ] Verify Write/Edit/Read/Bash validators block unauthorized operations during analysis
- [ ] Verify originating session cannot read raw development records (only sanitized report)
- [ ] Verify concurrent sessions are not affected by methodology analysis restrictions
- [ ] Verify monitor and statusline display correct status during analysis phase