### PR TITLE
Use portable shebang across all shell scripts

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -8,7 +8,7 @@
       "name": "humanize",
       "source": "./",
       "description": "Humanize - An iterative development plugin that uses Codex to review Claude's work. Creates a feedback loop where Claude implements plans and Codex independently reviews progress, ensuring quality through continuous refinement.",
-      "version": "1.14.0"
+      "version": "1.14.1"
     }
   ]
 }

--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "humanize",
   "description": "Humanize - An iterative development plugin that uses Codex to review Claude's work. Creates a feedback loop where Claude implements plans and Codex independently reviews progress, ensuring quality through continuous refinement.",
-  "version": "1.14.0",
+  "version": "1.14.1",
   "author": {
     "name": "humania-org"
   },

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # Humanize
 
-**Current Version: 1.14.0**
+**Current Version: 1.14.1**
 
 > Derived from the [GAAC (GitHub-as-a-Context)](https://github.com/SihaoLiu/gaac) project.
 

--- a/hooks/lib/loop-common.sh
+++ b/hooks/lib/loop-common.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 #
 # Common functions for RLCR loop hooks
 #

--- a/hooks/lib/template-loader.sh
+++ b/hooks/lib/template-loader.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 #
 # Template loading functions for RLCR loop hooks
 #

--- a/hooks/loop-bash-validator.sh
+++ b/hooks/loop-bash-validator.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 #
 # PreToolUse Hook: Validate Bash commands for RLCR loop and PR loop
 #

--- a/hooks/loop-codex-stop-hook.sh
+++ b/hooks/loop-codex-stop-hook.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 #
 # Stop Hook for RLCR loop
 #

--- a/hooks/loop-edit-validator.sh
+++ b/hooks/loop-edit-validator.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 #
 # PreToolUse Hook: Validate Edit paths for RLCR loop and PR loop
 #

--- a/hooks/loop-plan-file-validator.sh
+++ b/hooks/loop-plan-file-validator.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 #
 # UserPromptSubmit hook for plan file validation during RLCR loop
 #

--- a/hooks/loop-post-bash-hook.sh
+++ b/hooks/loop-post-bash-hook.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 #
 # PostToolUse Bash Hook for RLCR loop
 #

--- a/hooks/loop-read-validator.sh
+++ b/hooks/loop-read-validator.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 #
 # PreToolUse Hook: Validate Read access for RLCR loop and PR loop files
 #

--- a/hooks/loop-write-validator.sh
+++ b/hooks/loop-write-validator.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 #
 # PreToolUse Hook: Validate Write paths for RLCR loop and PR loop
 #

--- a/hooks/pr-loop-stop-hook.sh
+++ b/hooks/pr-loop-stop-hook.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 #
 # Stop Hook for PR loop
 #

--- a/scripts/ask-codex.sh
+++ b/scripts/ask-codex.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 #
 # Ask Codex - One-shot consultation with Codex
 #

--- a/scripts/cancel-pr-loop.sh
+++ b/scripts/cancel-pr-loop.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 #
 # Cancel script for cancel-pr-loop
 #

--- a/scripts/cancel-rlcr-loop.sh
+++ b/scripts/cancel-rlcr-loop.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 #
 # Cancel script for cancel-rlcr-loop
 #

--- a/scripts/check-bot-reactions.sh
+++ b/scripts/check-bot-reactions.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 #
 # Check bot reactions on PR or comments
 #

--- a/scripts/check-pr-reviewer-status.sh
+++ b/scripts/check-pr-reviewer-status.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 #
 # Check PR reviewer status for startup case determination
 #

--- a/scripts/fetch-pr-comments.sh
+++ b/scripts/fetch-pr-comments.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 #
 # Fetch PR comments from GitHub
 #

--- a/scripts/humanize.sh
+++ b/scripts/humanize.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 # humanize.sh - Humanize shell utilities
 # Part of rc.d configuration
 # Compatible with both bash and zsh

--- a/scripts/install-skill.sh
+++ b/scripts/install-skill.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 #
 # Install/upgrade Humanize skills for Kimi and/or Codex.
 #

--- a/scripts/install-skills-codex.sh
+++ b/scripts/install-skills-codex.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 #
 # Convenience wrapper: install Humanize skills for Codex target.
 #

--- a/scripts/install-skills-kimi.sh
+++ b/scripts/install-skills-kimi.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 #
 # Convenience wrapper: install Humanize skills for Kimi target.
 #

--- a/scripts/lib/monitor-common.sh
+++ b/scripts/lib/monitor-common.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 #
 # monitor-common.sh - Shared utilities for humanize monitor functions
 #

--- a/scripts/lib/monitor-skill.sh
+++ b/scripts/lib/monitor-skill.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 #
 # monitor-skill.sh - Skill monitor for humanize
 #

--- a/scripts/poll-pr-reviews.sh
+++ b/scripts/poll-pr-reviews.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 #
 # Poll for new PR reviews from specified bots
 #

--- a/scripts/portable-timeout.sh
+++ b/scripts/portable-timeout.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 #
 # Portable timeout wrapper for macOS/Linux compatibility
 # Usage: source portable-timeout.sh; run_with_timeout <seconds> <command> [args...]

--- a/scripts/rlcr-stop-gate.sh
+++ b/scripts/rlcr-stop-gate.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 #
 # Run RLCR stop-hook logic from non-hook environments (e.g. skill workflows).
 #

--- a/scripts/setup-pr-loop.sh
+++ b/scripts/setup-pr-loop.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 #
 # Setup script for start-pr-loop
 #

--- a/scripts/setup-rlcr-loop.sh
+++ b/scripts/setup-rlcr-loop.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 #
 # Setup script for start-rlcr-loop
 #

--- a/scripts/validate-gen-plan-io.sh
+++ b/scripts/validate-gen-plan-io.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 # validate-gen-plan-io.sh
 # Validates input and output paths for the gen-plan command
 # Exit codes:

--- a/tests/manual-monitor-test.sh
+++ b/tests/manual-monitor-test.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 #
 # Manual Test Script for tests
 #

--- a/tests/mocks/gh
+++ b/tests/mocks/gh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 #
 # Mock gh CLI for testing PR loop functionality
 #

--- a/tests/robustness/test-base-branch-detection.sh
+++ b/tests/robustness/test-base-branch-detection.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 #
 # Robustness tests for base branch auto-detection
 #

--- a/tests/robustness/test-cancel-security-robustness.sh
+++ b/tests/robustness/test-cancel-security-robustness.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 #
 # Robustness tests for cancel operation security
 #

--- a/tests/robustness/test-concurrent-state-robustness.sh
+++ b/tests/robustness/test-concurrent-state-robustness.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 #
 # Robustness tests for concurrent state access
 #

--- a/tests/robustness/test-git-operations-robustness.sh
+++ b/tests/robustness/test-git-operations-robustness.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 #
 # Robustness tests for git operation scripts
 #

--- a/tests/robustness/test-goal-tracker-robustness.sh
+++ b/tests/robustness/test-goal-tracker-robustness.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 #
 # Robustness tests for goal tracker parsing
 #

--- a/tests/robustness/test-hook-input-robustness.sh
+++ b/tests/robustness/test-hook-input-robustness.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 #
 # Robustness tests for hook input parsing and monitor edge cases
 #
@@ -453,7 +453,7 @@ cd "$MONITOR_TEST_DIR/project"
 
 # Create monitor runner script
 cat > "$MONITOR_TEST_DIR/run_monitor.sh" << 'MONITOR_EOF'
-#!/bin/bash
+#!/usr/bin/env bash
 PROJECT_DIR="$1"
 PROJECT_ROOT="$2"
 FAKE_HOME="$3"
@@ -512,7 +512,7 @@ echo "Test log" > "$FAKE_HOME_MONITOR/.cache/humanize/$SANITIZED/2026-01-17_10-0
 
 # Create narrow terminal runner - calls _humanize_monitor_codex directly in same shell
 cat > "$MONITOR_TEST_DIR/run_narrow.sh" << 'NARROW_EOF'
-#!/bin/bash
+#!/usr/bin/env bash
 PROJECT_DIR="$1"
 PROJECT_ROOT="$2"
 FAKE_HOME="$3"
@@ -603,7 +603,7 @@ mkdir -p "$FAKE_HOME_MONITOR/.cache/humanize/$SANITIZED3/2026-01-17_11-00-00"
 printf '\033[31mRed text\033[0m\n\033[1;32mBold green\033[0m\n' > "$FAKE_HOME_MONITOR/.cache/humanize/$SANITIZED3/2026-01-17_11-00-00/round-1-codex-run.log"
 
 cat > "$MONITOR_TEST_DIR/run_ansi.sh" << 'ANSI_EOF'
-#!/bin/bash
+#!/usr/bin/env bash
 PROJECT_DIR="$1"
 PROJECT_ROOT="$2"
 FAKE_HOME="$3"

--- a/tests/robustness/test-hook-system-robustness.sh
+++ b/tests/robustness/test-hook-system-robustness.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 #
 # Robustness tests for all hook scripts
 #
@@ -592,7 +592,7 @@ cd - > /dev/null
 # Create mock codex to avoid real API calls (review_started: false triggers codex exec)
 mkdir -p "$TEST_DIR/mock-bin"
 cat > "$TEST_DIR/mock-bin/codex" << 'MOCKEOF'
-#!/bin/bash
+#!/usr/bin/env bash
 # Mock codex that returns review output indicating work continues
 echo "Review: Code looks good but more testing needed."
 echo "No COMPLETE or STOP markers - work should continue."

--- a/tests/robustness/test-path-validation-robustness.sh
+++ b/tests/robustness/test-path-validation-robustness.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 #
 # Robustness tests for path validation
 #
@@ -22,7 +22,7 @@ setup_test_dir
 setup_mock_codex() {
     mkdir -p "$TEST_DIR/bin"
     cat > "$TEST_DIR/bin/codex" << 'MOCKEOF'
-#!/bin/bash
+#!/usr/bin/env bash
 # Mock codex for test-path-validation-robustness.sh
 echo "Mock codex output"
 exit 0

--- a/tests/robustness/test-plan-file-robustness.sh
+++ b/tests/robustness/test-plan-file-robustness.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 #
 # Robustness tests for plan file validation
 #
@@ -27,7 +27,7 @@ mkdir -p "$XDG_CACHE_HOME"
 setup_mock_codex() {
     mkdir -p "$TEST_DIR/bin"
     cat > "$TEST_DIR/bin/codex" << 'MOCKEOF'
-#!/bin/bash
+#!/usr/bin/env bash
 # Mock codex for test-plan-file-robustness.sh
 echo "Mock codex output"
 exit 0

--- a/tests/robustness/test-pr-loop-api-fetch.sh
+++ b/tests/robustness/test-pr-loop-api-fetch.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 #
 # PR Loop API fetch/state tests (parallel split 1/2)
 #

--- a/tests/robustness/test-pr-loop-api-poll.sh
+++ b/tests/robustness/test-pr-loop-api-poll.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 #
 # PR Loop API poll/stop-hook tests (parallel split 2/2)
 #

--- a/tests/robustness/test-pr-loop-api-robustness.sh
+++ b/tests/robustness/test-pr-loop-api-robustness.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 #
 # Robustness tests for PR loop API handling
 #
@@ -41,7 +41,7 @@ create_mock_gh() {
     # fetch-pr-comments.sh uses: gh repo view --json owner,name -q '...'
     #                           gh pr view PR --repo REPO --json number -q .number
     cat > "$dir/bin/gh" << 'GHEOF_START'
-#!/bin/bash
+#!/usr/bin/env bash
 # Mock gh command for testing
 
 # Check for -q flag anywhere in args (jq query)
@@ -694,7 +694,7 @@ run_poll_tests() {
     # Create a mock gh that sleeps briefly but responds
     mkdir -p "$TEST_DIR/poll2/bin"
     cat > "$TEST_DIR/poll2/bin/gh" << 'GHEOF'
-#!/bin/bash
+#!/usr/bin/env bash
 # Handle repo view
 if [[ "$1" == "repo" && "$2" == "view" ]]; then
     if [[ "$*" == *"--json"* ]]; then
@@ -761,7 +761,7 @@ GHEOF
     # Create a mock gh that fails on API calls
     mkdir -p "$TEST_DIR/poll3/bin"
     cat > "$TEST_DIR/poll3/bin/gh" << 'GHEOF'
-#!/bin/bash
+#!/usr/bin/env bash
 # Check for -q flag anywhere in args (jq query)
 HAS_Q_FLAG=false
 for arg in "$@"; do

--- a/tests/robustness/test-session-robustness.sh
+++ b/tests/robustness/test-session-robustness.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 #
 # Robustness tests for concurrent session handling
 #

--- a/tests/robustness/test-setup-scripts-robustness.sh
+++ b/tests/robustness/test-setup-scripts-robustness.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 #
 # Robustness tests for setup scripts
 #
@@ -60,6 +60,23 @@ init_basic_git_repo() {
     git add file.txt
     git commit -q -m "Initial commit"
     cd - > /dev/null
+}
+
+# Create a minimal PATH toolset in a test bin directory so scripts using
+# '/usr/bin/env bash' still run even in restricted PATH scenarios.
+prepare_runtime_bin() {
+    local bin_dir="$1"
+    local tool
+    local tool_path
+
+    mkdir -p "$bin_dir"
+
+    for tool in bash env git dirname cat sed awk grep mkdir date head od tr wc sort ls rm cp mv chmod ln readlink printf timeout gtimeout; do
+        tool_path=$(command -v "$tool" 2>/dev/null || true)
+        if [[ -n "$tool_path" && -x "$tool_path" && ! -e "$bin_dir/$tool" ]]; then
+            ln -s "$tool_path" "$bin_dir/$tool"
+        fi
+    done
 }
 
 # Run setup-rlcr-loop.sh with proper isolation from real RLCR loop
@@ -720,7 +737,7 @@ init_basic_git_repo "$TEST_DIR/repo30"
 # Create mock gh that fails auth check (to test dependency handling)
 mkdir -p "$TEST_DIR/repo30/bin"
 cat > "$TEST_DIR/repo30/bin/gh" << 'EOF'
-#!/bin/bash
+#!/usr/bin/env bash
 if [[ "$1" == "auth" && "$2" == "status" ]]; then
     echo "Not logged in" >&2
     exit 1
@@ -816,7 +833,7 @@ REAL_GIT=$(command -v git)
 
 # Mock timeout that returns 124 for git rev-parse (first check in setup script)
 cat > "$TEST_DIR/repo34/bin/timeout" << TIMEOUTEOF
-#!/bin/bash
+#!/usr/bin/env bash
 # Mock timeout that returns 124 for git rev-parse to simulate timeout
 if [[ "\$*" == *"git"*"rev-parse"* ]]; then
     exit 124
@@ -833,7 +850,7 @@ chmod +x "$TEST_DIR/repo34/bin/gtimeout"
 
 # Create mock codex
 cat > "$TEST_DIR/repo34/bin/codex" << 'CODEXEOF'
-#!/bin/bash
+#!/usr/bin/env bash
 exit 0
 CODEXEOF
 chmod +x "$TEST_DIR/repo34/bin/codex"
@@ -1092,13 +1109,14 @@ git -C "$TEST_DIR/repo46" add .gitignore && git -C "$TEST_DIR/repo46" commit -q 
 
 # Create bin dir with jq but no codex
 mkdir -p "$TEST_DIR/repo46/bin"
+prepare_runtime_bin "$TEST_DIR/repo46/bin"
 cat > "$TEST_DIR/repo46/bin/jq" << 'EOF'
-#!/bin/bash
+#!/usr/bin/env bash
 exit 0
 EOF
 chmod +x "$TEST_DIR/repo46/bin/jq"
-# Hide system codex by making the only codex on PATH our empty bin dir
-OUTPUT=$(PATH="$TEST_DIR/repo46/bin:/usr/bin:/bin" run_rlcr_setup "$TEST_DIR/repo46" plan.md 2>&1) || EXIT_CODE=$?
+# Hide system codex by making the only codex on PATH our test bin dir
+OUTPUT=$(PATH="$TEST_DIR/repo46/bin" run_rlcr_setup "$TEST_DIR/repo46" plan.md 2>&1) || EXIT_CODE=$?
 EXIT_CODE=${EXIT_CODE:-0}
 if [[ $EXIT_CODE -ne 0 ]] && echo "$OUTPUT" | grep -qi "Missing required dependencies" && echo "$OUTPUT" | grep -q "codex"; then
     pass "Missing codex detected in dependency check"
@@ -1121,13 +1139,14 @@ git -C "$TEST_DIR/repo47" add .gitignore && git -C "$TEST_DIR/repo47" commit -q 
 
 # Create bin dir with codex but no jq
 mkdir -p "$TEST_DIR/repo47/bin"
+prepare_runtime_bin "$TEST_DIR/repo47/bin"
 cat > "$TEST_DIR/repo47/bin/codex" << 'EOF'
-#!/bin/bash
+#!/usr/bin/env bash
 exit 0
 EOF
 chmod +x "$TEST_DIR/repo47/bin/codex"
-# Use a restricted PATH that has git but no jq
-OUTPUT=$(PATH="$TEST_DIR/repo47/bin:/usr/bin:/bin" run_rlcr_setup "$TEST_DIR/repo47" plan.md 2>&1) || EXIT_CODE=$?
+# Use a restricted PATH with required runtime tools but no jq
+OUTPUT=$(PATH="$TEST_DIR/repo47/bin" run_rlcr_setup "$TEST_DIR/repo47" plan.md 2>&1) || EXIT_CODE=$?
 EXIT_CODE=${EXIT_CODE:-0}
 if [[ $EXIT_CODE -ne 0 ]] && echo "$OUTPUT" | grep -qi "Missing required dependencies" && echo "$OUTPUT" | grep -q "jq"; then
     pass "Missing jq detected in dependency check"

--- a/tests/robustness/test-state-file-robustness.sh
+++ b/tests/robustness/test-state-file-robustness.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 #
 # Robustness tests for state file parsing
 #

--- a/tests/robustness/test-state-transition-robustness.sh
+++ b/tests/robustness/test-state-transition-robustness.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 #
 # Robustness tests for state transition logic
 #

--- a/tests/robustness/test-template-error-robustness.sh
+++ b/tests/robustness/test-template-error-robustness.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 #
 # Robustness tests for template system error handling
 #

--- a/tests/robustness/test-template-stress-robustness.sh
+++ b/tests/robustness/test-template-stress-robustness.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 #
 # Robustness tests for template system stress conditions
 #

--- a/tests/robustness/test-timeout-robustness.sh
+++ b/tests/robustness/test-timeout-robustness.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 #
 # Robustness tests for timeout implementation
 #

--- a/tests/run-all-tests.sh
+++ b/tests/run-all-tests.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 #
 # Run all test suites for the Humanize plugin (parallel execution)
 #
@@ -98,7 +98,7 @@ trap "rm -rf $OUTPUT_DIR" EXIT
 if ! command -v codex &>/dev/null; then
     mkdir -p "$OUTPUT_DIR/mock-bin"
     cat > "$OUTPUT_DIR/mock-bin/codex" << 'MOCK_CODEX'
-#!/bin/bash
+#!/usr/bin/env bash
 exit 0
 MOCK_CODEX
     chmod +x "$OUTPUT_DIR/mock-bin/codex"

--- a/tests/setup-fixture-mock-gh.sh
+++ b/tests/setup-fixture-mock-gh.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 #
 # Create a mock gh CLI that returns fixture data for testing
 # fetch-pr-comments.sh and poll-pr-reviews.sh
@@ -25,7 +25,7 @@ mkdir -p "$MOCK_BIN_DIR"
 
 # Create mock gh that returns fixtures
 cat > "$MOCK_BIN_DIR/gh" << MOCK_GH_EOF
-#!/bin/bash
+#!/usr/bin/env bash
 # Fixture-backed mock gh CLI for testing fetch/poll scripts
 
 FIXTURES_DIR="$FIXTURES_DIR"

--- a/tests/setup-monitor-test-env.sh
+++ b/tests/setup-monitor-test-env.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 #
 # Helper script to set up monitor test environment
 # This script creates the necessary directory structure and state files

--- a/tests/test-agent-teams.sh
+++ b/tests/test-agent-teams.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 #
 # Tests for --agent-teams feature in RLCR loop
 #
@@ -498,7 +498,7 @@ setup_mock_codex_impl_feedback() {
     local feedback="$1"
     mkdir -p "$TEST_DIR/bin"
     cat > "$TEST_DIR/bin/codex" << MOCK_EOF
-#!/bin/bash
+#!/usr/bin/env bash
 if [[ "\$1" == "exec" ]]; then
     cat << 'REVIEW'
 $feedback
@@ -516,7 +516,7 @@ setup_mock_codex_review_issues() {
     local review_output="$1"
     mkdir -p "$TEST_DIR/bin"
     cat > "$TEST_DIR/bin/codex" << MOCK_EOF
-#!/bin/bash
+#!/usr/bin/env bash
 if [[ "\$1" == "exec" ]]; then
     echo "Should not be called in review phase"
 elif [[ "\$1" == "review" ]]; then

--- a/tests/test-allowlist-validators.sh
+++ b/tests/test-allowlist-validators.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 #
 # Tests for allowlist behavior in RLCR loop validators
 #

--- a/tests/test-ansi-parsing.sh
+++ b/tests/test-ansi-parsing.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 #
 # Test ANSI escape code handling in test runner output parsing
 #

--- a/tests/test-ask-codex.sh
+++ b/tests/test-ask-codex.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 #
 # Tests for ask-codex.sh - one-shot consultation with mock Codex
 #
@@ -36,7 +36,7 @@ MOCK_BIN_DIR="$TEST_DIR/mock-bin"
 mkdir -p "$MOCK_BIN_DIR"
 
 cat > "$MOCK_BIN_DIR/codex" << 'MOCK_EOF'
-#!/bin/bash
+#!/usr/bin/env bash
 # Mock codex binary for testing ask-codex.sh
 # Controlled via environment variables.
 if [[ -n "${MOCK_CODEX_STDERR:-}" ]]; then

--- a/tests/test-bash-validator-patterns.sh
+++ b/tests/test-bash-validator-patterns.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 #
 # Test script for command_modifies_file function in loop-common.sh
 #

--- a/tests/test-cancel-signal-file.sh
+++ b/tests/test-cancel-signal-file.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 #
 # Tests for cancel-rlcr-loop signal file mechanism
 #

--- a/tests/test-codex-review-merge.sh
+++ b/tests/test-codex-review-merge.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 #
 # Tests for Code Review log file analysis behavior
 #

--- a/tests/test-error-scenarios.sh
+++ b/tests/test-error-scenarios.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 #
 # Test error scenarios for template-loader.sh
 #

--- a/tests/test-finalize-phase.sh
+++ b/tests/test-finalize-phase.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 #
 # Tests for Finalize Phase feature
 #
@@ -55,7 +55,7 @@ setup_mock_codex() {
     local review_output="${2:-No issues found.}"
     mkdir -p "$TEST_DIR/bin"
     cat > "$TEST_DIR/bin/codex" << EOF
-#!/bin/bash
+#!/usr/bin/env bash
 # Mock codex - outputs the provided content
 if [[ "\$1" == "exec" ]]; then
     cat << 'REVIEW'
@@ -79,7 +79,7 @@ setup_mock_codex_with_tracking() {
     local review_output="${2:-No issues found.}"
     mkdir -p "$TEST_DIR/bin"
     cat > "$TEST_DIR/bin/codex" << EOF
-#!/bin/bash
+#!/usr/bin/env bash
 # Track that codex was called
 echo "CODEX_WAS_CALLED" > "$TEST_DIR/codex_called.marker"
 if [[ "\$1" == "exec" ]]; then
@@ -104,7 +104,7 @@ setup_mock_codex_review_failure() {
     local review_exit_code="${2:-1}"
     mkdir -p "$TEST_DIR/bin"
     cat > "$TEST_DIR/bin/codex" << EOF
-#!/bin/bash
+#!/usr/bin/env bash
 # Mock codex - fails on review command
 if [[ "\$1" == "exec" ]]; then
     cat << 'REVIEW'
@@ -126,7 +126,7 @@ setup_mock_codex_review_empty_stdout() {
     local exec_output="$1"
     mkdir -p "$TEST_DIR/bin"
     cat > "$TEST_DIR/bin/codex" << EOF
-#!/bin/bash
+#!/usr/bin/env bash
 # Mock codex - produces empty stdout on review
 if [[ "\$1" == "exec" ]]; then
     cat << 'REVIEW'

--- a/tests/test-gen-plan.sh
+++ b/tests/test-gen-plan.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 #
 # Test script for gen-plan command structure validation
 #

--- a/tests/test-helpers.sh
+++ b/tests/test-helpers.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 #
 # Shared test helper functions for all test scripts
 #

--- a/tests/test-humanize-escape.sh
+++ b/tests/test-humanize-escape.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 #
 # Test script for humanize-escape fixes
 #

--- a/tests/test-monitor-e2e-deletion.sh
+++ b/tests/test-monitor-e2e-deletion.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 # Monitor e2e deletion tests (parallel split 1/3)
 set -euo pipefail
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"

--- a/tests/test-monitor-e2e-real.sh
+++ b/tests/test-monitor-e2e-real.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 #
 # TRUE End-to-End Monitor Tests for monitor tests
 #
@@ -105,7 +105,7 @@ GOALTRACKER_EOF1
     # Create the test runner script
     # This script runs the REAL _humanize_monitor_codex function
     cat > "$TEST_PROJECT/run_real_monitor.sh" << 'MONITOR_SCRIPT'
-#!/bin/bash
+#!/usr/bin/env bash
 # Run the REAL _humanize_monitor_codex function
 
 PROJECT_DIR="$1"
@@ -426,7 +426,7 @@ GOALTRACKER_SIGINT
 
     # Create the test runner script for SIGINT test
     cat > "$TEST_PROJECT_SIGINT/run_real_monitor_sigint.sh" << 'SIGINT_SCRIPT_EOF'
-#!/bin/bash
+#!/usr/bin/env bash
 # Run the REAL _humanize_monitor_codex function for SIGINT testing
 
 PROJECT_DIR="$1"
@@ -747,7 +747,7 @@ GOALTRACKER_EOF
 
     # Create bash test runner script for PR monitor
     cat > "$TEST_PROJECT_PR/run_real_monitor_pr.sh" << 'MONITOR_SCRIPT'
-#!/bin/bash
+#!/usr/bin/env bash
 # Run the REAL _humanize_monitor_pr function
 
 PROJECT_DIR="$1"
@@ -890,7 +890,7 @@ PR_GOAL_EOF
 
     # Create bash test runner script for PR monitor without --once
     cat > "$TEST_PROJECT_PR_NO_ONCE/run_real_monitor_pr_no_once.sh" << 'PR_NO_ONCE_EOF'
-#!/bin/bash
+#!/usr/bin/env bash
 # Run the REAL _humanize_monitor_pr function WITHOUT --once flag
 
 PROJECT_DIR="$1"

--- a/tests/test-monitor-e2e-sigint.sh
+++ b/tests/test-monitor-e2e-sigint.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 # Monitor e2e SIGINT tests (parallel split 2/3)
 set -euo pipefail
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"

--- a/tests/test-monitor-runtime.sh
+++ b/tests/test-monitor-runtime.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 #
 # Runtime Verification Tests for tests
 #
@@ -63,7 +63,7 @@ echo "current_round: 1" > .humanize/rlcr/2026-01-16_10-00-00/state.md
 
 # Create a test script that sources humanize.sh and tests the graceful stop behavior
 cat > test_graceful_stop.sh << 'TESTSCRIPT'
-#!/bin/bash
+#!/usr/bin/env bash
 cd "$1"
 
 # Source the monitor script
@@ -141,7 +141,7 @@ echo "Test 2: Verify cleanup prevents double execution"
 echo ""
 
 cat > test_double_cleanup.sh << 'TESTSCRIPT'
-#!/bin/bash
+#!/usr/bin/env bash
 cleanup_done=false
 call_count=0
 
@@ -184,7 +184,7 @@ echo "Test 3: Main loop directory deletion detection"
 echo ""
 
 cat > test_loop_detection.sh << 'TESTSCRIPT'
-#!/bin/bash
+#!/usr/bin/env bash
 cd "$1"
 
 loop_dir=".humanize/rlcr"
@@ -261,7 +261,7 @@ echo ""
 # and would reset the scroll region
 
 cat > test_terminal_restore.sh << 'TESTSCRIPT'
-#!/bin/bash
+#!/usr/bin/env bash
 # Test that _restore_terminal is defined and callable
 
 cd "$1"
@@ -331,7 +331,7 @@ echo "Test 6: SIGINT triggers cleanup in bash"
 echo ""
 
 cat > test_sigint_bash.sh << 'TESTSCRIPT'
-#!/bin/bash
+#!/usr/bin/env bash
 # Test that SIGINT triggers cleanup in bash mode
 
 cleanup_done=false

--- a/tests/test-plan-file-hooks.sh
+++ b/tests/test-plan-file-hooks.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 #
 # Tests for plan file hooks during RLCR loop
 #
@@ -40,7 +40,7 @@ mkdir -p "$XDG_CACHE_HOME"
 setup_mock_codex() {
     mkdir -p "$TEST_DIR/bin"
     cat > "$TEST_DIR/bin/codex" << 'MOCKEOF'
-#!/bin/bash
+#!/usr/bin/env bash
 # Mock codex for test-plan-file-hooks.sh
 if [[ "$1" == "exec" ]]; then
     echo "Mock review output"

--- a/tests/test-plan-file-validation.sh
+++ b/tests/test-plan-file-validation.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 #
 # Tests for plan file validation in setup-rlcr-loop.sh
 #
@@ -74,7 +74,7 @@ EOF
 mock_codex() {
     mkdir -p "$TEST_DIR/bin"
     cat > "$TEST_DIR/bin/codex" << 'EOF'
-#!/bin/bash
+#!/usr/bin/env bash
 # Mock codex for test-plan-file-validation.sh
 echo "mock codex"
 EOF

--- a/tests/test-pr-loop-1-scripts.sh
+++ b/tests/test-pr-loop-1-scripts.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 #
 # PR Loop Script Tests Runner (parallel split 1/3)
 #

--- a/tests/test-pr-loop-2-hooks.sh
+++ b/tests/test-pr-loop-2-hooks.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 #
 # PR Loop Hook Tests Runner (parallel split 2/3)
 #

--- a/tests/test-pr-loop-3-stophook.sh
+++ b/tests/test-pr-loop-3-stophook.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 #
 # PR Loop Stop Hook Tests Runner (parallel split 3/3)
 #

--- a/tests/test-pr-loop-hooks.sh
+++ b/tests/test-pr-loop-hooks.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 #
 # PR Loop Hook Tests
 #
@@ -482,7 +482,7 @@ create_enhanced_mock_gh() {
     local trigger_timestamp="${3:-2026-01-18T12:00:00Z}"
 
     cat > "$mock_dir/gh" << MOCK_GH
-#!/bin/bash
+#!/usr/bin/env bash
 # Enhanced mock gh CLI for stop hook testing
 
 case "\$1" in
@@ -542,7 +542,7 @@ test_trigger_user_filter() {
 
     # Create mock that returns comments from different users
     cat > "$test_subdir/gh" << 'MOCK_GH'
-#!/bin/bash
+#!/usr/bin/env bash
 case "$1" in
     api)
         if [[ "$2" == "user" ]]; then
@@ -794,7 +794,7 @@ EOF
     mkdir -p "$mock_bin"
 
     cat > "$mock_bin/gh" << 'MOCK_GH'
-#!/bin/bash
+#!/usr/bin/env bash
 case "$1" in
     api)
         if [[ "$2" == "user" ]]; then
@@ -816,7 +816,7 @@ MOCK_GH
     chmod +x "$mock_bin/gh"
 
     cat > "$mock_bin/git" << 'MOCK_GIT'
-#!/bin/bash
+#!/usr/bin/env bash
 case "$1" in
     rev-parse) echo "/tmp/git" ;;
     status) echo "" ;;
@@ -877,7 +877,7 @@ EOF
 
     # Mock gh that properly returns jq-parsed user and trigger comments
     cat > "$mock_bin/gh" << 'MOCK_GH'
-#!/bin/bash
+#!/usr/bin/env bash
 case "$1" in
     api)
         if [[ "$2" == "user" ]]; then
@@ -916,7 +916,7 @@ MOCK_GH
     chmod +x "$mock_bin/gh"
 
     cat > "$mock_bin/git" << 'MOCK_GIT'
-#!/bin/bash
+#!/usr/bin/env bash
 case "$1" in
     rev-parse) echo "/tmp/git" ;;
     status) echo "" ;;
@@ -979,7 +979,7 @@ EOF
     # Mock gh that simulates paginated response (returns multiple JSON arrays)
     # The trigger comment is on page 2 (second array) - only visible if pagination works
     cat > "$mock_bin/gh" << 'MOCK_GH'
-#!/bin/bash
+#!/usr/bin/env bash
 case "$1" in
     api)
         if [[ "$2" == "user" ]]; then
@@ -1023,7 +1023,7 @@ MOCK_GH
     chmod +x "$mock_bin/gh"
 
     cat > "$mock_bin/git" << 'MOCK_GIT'
-#!/bin/bash
+#!/usr/bin/env bash
 case "$1" in
     rev-parse) echo "/tmp/git" ;;
     status) echo "" ;;
@@ -1084,7 +1084,7 @@ EOF
     mkdir -p "$mock_bin"
 
     cat > "$mock_bin/gh" << 'MOCK_GH'
-#!/bin/bash
+#!/usr/bin/env bash
 case "$1" in
     api)
         if [[ "$2" == "user" ]]; then
@@ -1112,7 +1112,7 @@ MOCK_GH
     chmod +x "$mock_bin/gh"
 
     cat > "$mock_bin/git" << 'MOCK_GIT'
-#!/bin/bash
+#!/usr/bin/env bash
 case "$1" in
     rev-parse) echo "/tmp/git" ;;
     status) echo "" ;;

--- a/tests/test-pr-loop-lib.sh
+++ b/tests/test-pr-loop-lib.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 #
 # Common library for PR loop tests
 #
@@ -30,7 +30,7 @@ if [[ -z "${TEST_PR_LOOP_LIB_LOADED:-}" ]]; then
         mkdir -p "$mock_dir"
 
         cat > "$mock_dir/gh" << 'MOCK_GH'
-#!/bin/bash
+#!/usr/bin/env bash
 # Mock gh CLI for testing
 
 case "$1" in
@@ -92,7 +92,7 @@ MOCK_GH
         local mock_dir="$1"
 
         cat > "$mock_dir/codex" << 'MOCK_CODEX'
-#!/bin/bash
+#!/usr/bin/env bash
 # Mock codex CLI for testing
 echo "Mock codex output"
 exit 0

--- a/tests/test-pr-loop-scripts.sh
+++ b/tests/test-pr-loop-scripts.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 #
 # PR Loop Script Tests
 #

--- a/tests/test-pr-loop-stophook.sh
+++ b/tests/test-pr-loop-stophook.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 #
 # PR Loop Stop Hook Tests
 #
@@ -56,7 +56,7 @@ EOF
 
     # Mock gh that returns OLD trigger comment (BEFORE latest_commit_at)
     cat > "$mock_bin/gh" << 'MOCK_GH'
-#!/bin/bash
+#!/usr/bin/env bash
 # Check if --jq is in arguments (for transformed format)
 HAS_JQ=false
 for arg in "$@"; do
@@ -103,7 +103,7 @@ MOCK_GH
     chmod +x "$mock_bin/gh"
 
     cat > "$mock_bin/git" << 'MOCK_GIT'
-#!/bin/bash
+#!/usr/bin/env bash
 case "$1" in
     rev-parse)
         if [[ "$2" == "HEAD" ]]; then
@@ -175,7 +175,7 @@ EOF
 
     # Mock gh that returns no trigger comments, but has codex +1
     cat > "$mock_bin/gh" << 'MOCK_GH'
-#!/bin/bash
+#!/usr/bin/env bash
 case "$1" in
     api)
         if [[ "$2" == "user" ]]; then
@@ -206,7 +206,7 @@ MOCK_GH
     chmod +x "$mock_bin/gh"
 
     cat > "$mock_bin/git" << 'MOCK_GIT'
-#!/bin/bash
+#!/usr/bin/env bash
 case "$1" in
     rev-parse)
         if [[ "$2" == "HEAD" ]]; then
@@ -281,13 +281,13 @@ EOF
     mkdir -p "$mock_bin"
 
     cat > "$mock_bin/gh" << 'MOCK_GH'
-#!/bin/bash
+#!/usr/bin/env bash
 exit 0
 MOCK_GH
     chmod +x "$mock_bin/gh"
 
     cat > "$mock_bin/git" << 'MOCK_GIT'
-#!/bin/bash
+#!/usr/bin/env bash
 case "$1" in
     rev-parse)
         if [[ "$2" == "HEAD" ]]; then
@@ -363,7 +363,7 @@ EOF
 
     # Mock gh that returns bot comments (simulating comments arriving)
     cat > "$mock_bin/gh" << 'MOCK_GH'
-#!/bin/bash
+#!/usr/bin/env bash
 case "$1" in
     api)
         if [[ "$2" == "user" ]]; then
@@ -411,7 +411,7 @@ MOCK_GH
     chmod +x "$mock_bin/gh"
 
     cat > "$mock_bin/git" << 'MOCK_GIT'
-#!/bin/bash
+#!/usr/bin/env bash
 case "$1" in
     rev-parse)
         if [[ "$2" == "HEAD" ]]; then
@@ -485,14 +485,14 @@ EOF
     mkdir -p "$mock_bin"
 
     cat > "$mock_bin/gh" << 'MOCK_GH'
-#!/bin/bash
+#!/usr/bin/env bash
 exit 0
 MOCK_GH
     chmod +x "$mock_bin/gh"
 
     # Mock git that reports unpushed commits
     cat > "$mock_bin/git" << 'MOCK_GIT'
-#!/bin/bash
+#!/usr/bin/env bash
 case "$1" in
     rev-parse)
         if [[ "$2" == "HEAD" ]]; then
@@ -571,7 +571,7 @@ EOF
     mkdir -p "$mock_bin"
 
     cat > "$mock_bin/gh" << 'MOCK_GH'
-#!/bin/bash
+#!/usr/bin/env bash
 case "$1" in
     pr)
         if [[ "$*" == *"commits"* ]] && [[ "$*" == *"--jq"* ]]; then
@@ -595,7 +595,7 @@ MOCK_GH
 
     # Mock git that simulates force push: old commit is NOT ancestor of current HEAD
     cat > "$mock_bin/git" << 'MOCK_GIT'
-#!/bin/bash
+#!/usr/bin/env bash
 case "$1" in
     rev-parse)
         if [[ "$2" == "HEAD" ]]; then
@@ -676,7 +676,7 @@ EOF
 
     # Mock gh that returns no trigger comments
     cat > "$mock_bin/gh" << 'MOCK_GH'
-#!/bin/bash
+#!/usr/bin/env bash
 case "$1" in
     api)
         if [[ "$2" == "user" ]]; then
@@ -711,7 +711,7 @@ MOCK_GH
     chmod +x "$mock_bin/gh"
 
     cat > "$mock_bin/git" << 'MOCK_GIT'
-#!/bin/bash
+#!/usr/bin/env bash
 case "$1" in
     rev-parse)
         if [[ "$2" == "HEAD" ]]; then
@@ -788,7 +788,7 @@ EOF
 
     # Mock gh that returns NO bot comments (simulates bot not responding)
     cat > "$mock_bin/gh" << 'MOCK_GH'
-#!/bin/bash
+#!/usr/bin/env bash
 case "$1" in
     api)
         if [[ "$2" == "user" ]]; then
@@ -820,7 +820,7 @@ MOCK_GH
     chmod +x "$mock_bin/gh"
 
     cat > "$mock_bin/git" << 'MOCK_GIT'
-#!/bin/bash
+#!/usr/bin/env bash
 case "$1" in
     rev-parse)
         if [[ "$2" == "HEAD" ]]; then
@@ -930,7 +930,7 @@ EOF
 
     # Mock gh that returns +1 reaction from codex
     cat > "$mock_bin/gh" << 'MOCK_GH'
-#!/bin/bash
+#!/usr/bin/env bash
 case "$1" in
     api)
         if [[ "$2" == "user" ]]; then
@@ -966,7 +966,7 @@ MOCK_GH
     chmod +x "$mock_bin/gh"
 
     cat > "$mock_bin/git" << 'MOCK_GIT'
-#!/bin/bash
+#!/usr/bin/env bash
 case "$1" in
     rev-parse)
         if [[ "$2" == "HEAD" ]]; then
@@ -1045,7 +1045,7 @@ EOF
 
     # Mock gh that returns NO eyes reaction (simulates claude bot not configured)
     cat > "$mock_bin/gh" << 'MOCK_GH'
-#!/bin/bash
+#!/usr/bin/env bash
 # Check if --jq is in arguments (for transformed format)
 HAS_JQ=false
 for arg in "$@"; do
@@ -1101,7 +1101,7 @@ MOCK_GH
     chmod +x "$mock_bin/gh"
 
     cat > "$mock_bin/git" << 'MOCK_GIT'
-#!/bin/bash
+#!/usr/bin/env bash
 case "$1" in
     rev-parse)
         if [[ "$2" == "HEAD" ]]; then
@@ -1193,7 +1193,7 @@ EOF
     # check-pr-reviewer-status.sh uses --jq so needs transformed format
     # Use COMMENT_TS environment variable for dynamic timestamp
     cat > "$mock_bin/gh" << MOCK_GH
-#!/bin/bash
+#!/usr/bin/env bash
 # Dynamic comment timestamp from test setup
 COMMENT_TS="$comment_ts"
 COMMIT_TS="$commit_ts"
@@ -1307,7 +1307,7 @@ MOCK_GH
     chmod +x "$mock_bin/gh"
 
     cat > "$mock_bin/git" << 'MOCK_GIT'
-#!/bin/bash
+#!/usr/bin/env bash
 case "$1" in
     rev-parse)
         if [[ "$2" == "HEAD" ]]; then
@@ -1425,7 +1425,7 @@ EOF
     # - Current repo (fork) doesn't have PR 456
     # - Parent repo (upstream) has PR 456
     cat > "$mock_bin/gh" << 'MOCK_GH'
-#!/bin/bash
+#!/usr/bin/env bash
 # Track which repo we're querying
 FORK_REPO="forkuser/forkrepo"
 UPSTREAM_REPO="upstreamowner/upstreamrepo"
@@ -1475,7 +1475,7 @@ MOCK_GH
     chmod +x "$mock_bin/gh"
 
     cat > "$mock_bin/git" << 'MOCK_GIT'
-#!/bin/bash
+#!/usr/bin/env bash
 case "$1" in
     rev-parse)
         if [[ "$2" == "HEAD" ]]; then
@@ -1583,7 +1583,7 @@ EOF
     # - claude: APPROVE (LGTM)
     # - codex: ISSUES (has issues)
     cat > "$mock_bin/gh" << MOCK_GH
-#!/bin/bash
+#!/usr/bin/env bash
 # Dynamic timestamps from test setup
 CLAUDE_TS="$claude_ts"
 CODEX_TS="$codex_ts"
@@ -1653,7 +1653,7 @@ MOCK_GH
     chmod +x "$mock_bin/gh"
 
     cat > "$mock_bin/git" << 'MOCK_GIT'
-#!/bin/bash
+#!/usr/bin/env bash
 case "$1" in
     rev-parse)
         if [[ "$2" == "HEAD" ]]; then
@@ -1677,7 +1677,7 @@ MOCK_GIT
 
     # Mock codex that outputs mixed approval
     cat > "$mock_bin/codex" << 'MOCK_CODEX'
-#!/bin/bash
+#!/usr/bin/env bash
 # Mock codex output: claude approves, codex has issues
 cat << 'CODEX_OUTPUT'
 # PR Review Validation

--- a/tests/test-pr-loop-system.sh
+++ b/tests/test-pr-loop-system.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 #
 # Test runner for PR loop system
 #
@@ -910,7 +910,7 @@ run_monitor_once_capture_output() {
     # Create wrapper script that runs monitor and captures output
     local wrapper="$project_dir/run_monitor_test.sh"
     cat > "$wrapper" << 'WRAPPER_EOF'
-#!/bin/bash
+#!/usr/bin/env bash
 PROJECT_DIR="$1"
 PROJECT_ROOT="$2"
 
@@ -1597,7 +1597,7 @@ EOF
     mkdir -p "$mock_bin"
 
     cat > "$mock_bin/gh" << MOCK_GH
-#!/bin/bash
+#!/usr/bin/env bash
 COMMENT_TS="$comment_ts"
 COMMIT_TS="$commit_ts"
 
@@ -1669,7 +1669,7 @@ MOCK_GH
     chmod +x "$mock_bin/gh"
 
     cat > "$mock_bin/git" << 'MOCK_GIT'
-#!/bin/bash
+#!/usr/bin/env bash
 case "$1" in
     rev-parse)
         if [[ "$2" == "HEAD" ]]; then
@@ -1691,7 +1691,7 @@ MOCK_GIT
 
     # Mock codex command - returns ISSUES_REMAINING to trigger goal tracker update
     cat > "$mock_bin/codex" << 'MOCK_CODEX'
-#!/bin/bash
+#!/usr/bin/env bash
 # Mock codex for testing - output review analysis
 cat << 'CODEX_OUTPUT'
 ## Bot Review Analysis

--- a/tests/test-pr-loop.sh
+++ b/tests/test-pr-loop.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 #
 # Tests for PR loop feature
 #

--- a/tests/test-session-id.sh
+++ b/tests/test-session-id.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 #
 # Tests for session_id feature in RLCR loop
 #

--- a/tests/test-skill-monitor.sh
+++ b/tests/test-skill-monitor.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 #
 # Tests for _humanize_monitor_skill (humanize monitor skill)
 #

--- a/tests/test-state-exit-naming.sh
+++ b/tests/test-state-exit-naming.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 #
 # Tests for state.md rename on exit
 #

--- a/tests/test-stop-gate.sh
+++ b/tests/test-stop-gate.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 #
 # Tests for rlcr-stop-gate wrapper project root detection
 #

--- a/tests/test-template-loader.sh
+++ b/tests/test-template-loader.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 #
 # Test script for template-loader.sh
 #

--- a/tests/test-template-references.sh
+++ b/tests/test-template-references.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 #
 # Template Reference Validation
 #

--- a/tests/test-templates-comprehensive.sh
+++ b/tests/test-templates-comprehensive.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 #
 # Comprehensive template validation tests for CI/CD
 #

--- a/tests/test-todo-checker.sh
+++ b/tests/test-todo-checker.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 #
 # Test script for check-todos-from-transcript.py
 #


### PR DESCRIPTION
Replace hardcoded `#!/bin/bash` with `#!/usr/bin/env bash` for better portability across different Unix systems where bash may be installed in non-standard locations.