### PR TITLE
Canonicalize paths across all humanize hooks and scripts

### DIFF
--- a/hooks/lib/loop-common.sh
+++ b/hooks/lib/loop-common.sh
@@ -190,7 +190,16 @@ _LOOP_COMMON_PROJECT_ROOT="$(resolve_project_root 2>/dev/null || true)"
 # Config loading is best-effort: use || true so a config-load failure does not
 # abort sourcing before callers' dependency checks (jq, codex) are reached.
 # Stderr is NOT suppressed so malformed config warnings remain visible.
-_LOOP_COMMON_CONFIG="$(load_merged_config "$LOOP_COMMON_PLUGIN_ROOT" "$_LOOP_COMMON_PROJECT_ROOT")" || true
+#
+# Skip config loading when no project root is available (e.g. humanize.sh is
+# sourced from .bashrc/.zshrc in a non-repo directory like $HOME). Passing an
+# empty project_root to load_merged_config would surface a usage error on
+# stderr every time the shell starts.
+if [[ -n "$_LOOP_COMMON_PROJECT_ROOT" ]]; then
+    _LOOP_COMMON_CONFIG="$(load_merged_config "$LOOP_COMMON_PLUGIN_ROOT" "$_LOOP_COMMON_PROJECT_ROOT")" || true
+else
+    _LOOP_COMMON_CONFIG=""
+fi
 
 # Load bitlesson model from merged config (controls which CLI bitlesson-select.sh uses)
 DEFAULT_BITLESSON_MODEL="$(get_config_value "$_LOOP_COMMON_CONFIG" "bitlesson_model" 2>/dev/null || true)"
@@ -1070,10 +1079,20 @@ is_cancel_authorized() {
         return 4
     fi
 
+    # Canonicalize the loop dir (idempotent: resolve_project_root already
+    # canonicalizes, but callers may supply a non-canonical override). Both
+    # sides of the upcoming string comparisons must be canonicalized through
+    # the same transformation or a symlinked prefix in the user's command
+    # (e.g. /var/... vs /private/var/... on macOS) will spuriously fail the
+    # authorization check.
+    local canonical_loop_dir
+    canonical_loop_dir="$(canonicalize_path "${active_loop_dir%/}")"
+    canonical_loop_dir="${canonical_loop_dir:-${active_loop_dir%/}}"
+
     # Normalize: Replace $loop_dir and ${loop_dir} with actual path
     local normalized="$command_lower"
     local loop_dir_lower
-    loop_dir_lower="${active_loop_dir%/}/"
+    loop_dir_lower="${canonical_loop_dir}/"
     loop_dir_lower=$(echo "$loop_dir_lower" | tr '[:upper:]' '[:lower:]')
 
     normalized="${normalized//\$\{loop_dir\}/$loop_dir_lower}"
@@ -1169,32 +1188,50 @@ is_cancel_authorized() {
         return 5
     fi
 
-    # Normalize and validate source path
+    # Normalize and validate source path.
+    #
+    # Canonicalize the user-provided path so a symlinked prefix in the caller's
+    # command (e.g. /Users/x vs /private/Users/x on macOS, or /var vs
+    # /private/var) matches canonical_loop_dir resolved via resolve_project_root.
+    # Re-lowercase after canonicalization because realpath on case-insensitive
+    # filesystems may restore the original casing of path components, which
+    # would diverge from the already-lowercased expected_* values.
     src=$(_normalize_path "$src")
+    local src_canonical
+    src_canonical="$(canonicalize_path "$src")"
+    src_canonical="${src_canonical:-$src}"
+    src_canonical=$(echo "$src_canonical" | tr '[:upper:]' '[:lower:]')
     local expected_src_state="${loop_dir_lower}state.md"
     local expected_src_finalize="${loop_dir_lower}finalize-state.md"
     local expected_src_methodology="${loop_dir_lower}methodology-analysis-state.md"
-    if [[ "$src" != "$expected_src_state" ]] && [[ "$src" != "$expected_src_finalize" ]] && [[ "$src" != "$expected_src_methodology" ]]; then
+    if [[ "$src_canonical" != "$expected_src_state" ]] && [[ "$src_canonical" != "$expected_src_finalize" ]] && [[ "$src_canonical" != "$expected_src_methodology" ]]; then
         return 5
     fi
 
-    # Normalize and validate destination path
+    # Normalize and validate destination path (same canonicalize+lowercase
+    # transformation as source; see src comment above for rationale).
     dest=$(_normalize_path "$dest")
+    local dest_canonical
+    dest_canonical="$(canonicalize_path "$dest")"
+    dest_canonical="${dest_canonical:-$dest}"
+    dest_canonical=$(echo "$dest_canonical" | tr '[:upper:]' '[:lower:]')
     local expected_dest="${loop_dir_lower}cancel-state.md"
-    if [[ "$dest" != "$expected_dest" ]]; then
+    if [[ "$dest_canonical" != "$expected_dest" ]]; then
         return 5
     fi
 
     # SECURITY: Reject if source file is a symlink (filesystem check)
     # Determine source file by comparing against expected paths (not substring match)
     # This avoids vulnerability when loop directory path contains "finalize" or "methodology"
+    # Use canonical_loop_dir so the symlink check runs against the real on-disk
+    # path rather than a user-supplied non-canonical form.
     local src_original
-    if [[ "$src" == "$expected_src_methodology" ]]; then
-        src_original="${active_loop_dir}/methodology-analysis-state.md"
-    elif [[ "$src" == "$expected_src_finalize" ]]; then
-        src_original="${active_loop_dir}/finalize-state.md"
+    if [[ "$src_canonical" == "$expected_src_methodology" ]]; then
+        src_original="${canonical_loop_dir}/methodology-analysis-state.md"
+    elif [[ "$src_canonical" == "$expected_src_finalize" ]]; then
+        src_original="${canonical_loop_dir}/finalize-state.md"
     else
-        src_original="${active_loop_dir}/state.md"
+        src_original="${canonical_loop_dir}/state.md"
     fi
     if [[ -L "$src_original" ]]; then
         return 6  # Source is a symlink

--- a/hooks/lib/loop-common.sh
+++ b/hooks/lib/loop-common.sh
@@ -173,6 +173,10 @@ LOOP_COMMON_DIR="$(cd "$(dirname "${BASH_SOURCE[0]:-$0}")" && pwd)"
 LOOP_COMMON_PLUGIN_ROOT="$(cd "$LOOP_COMMON_DIR/../.." && pwd)"
 export PLUGIN_ROOT="${PLUGIN_ROOT:-$LOOP_COMMON_PLUGIN_ROOT}"
 
+# Shared project-root resolver (CLAUDE_PROJECT_DIR -> git toplevel,
+# realpath-canonicalized). Must load before any caller needs PROJECT_ROOT.
+source "$LOOP_COMMON_DIR/project-root.sh"
+
 _lc_errexit=false; [[ -o errexit ]] && _lc_errexit=true
 _lc_nounset=false; [[ -o nounset ]] && _lc_nounset=true
 _lc_pipefail=false; [[ -o pipefail ]] && _lc_pipefail=true
@@ -182,7 +186,7 @@ $_lc_nounset && set -u || set +u
 $_lc_pipefail && set -o pipefail || set +o pipefail
 unset _lc_errexit _lc_nounset _lc_pipefail
 
-_LOOP_COMMON_PROJECT_ROOT="${CLAUDE_PROJECT_DIR:-$(git rev-parse --show-toplevel 2>/dev/null || pwd)}"
+_LOOP_COMMON_PROJECT_ROOT="$(resolve_project_root 2>/dev/null || true)"
 # Config loading is best-effort: use || true so a config-load failure does not
 # abort sourcing before callers' dependency checks (jq, codex) are reached.
 # Stderr is NOT suppressed so malformed config warnings remain visible.

--- a/hooks/lib/project-root.sh
+++ b/hooks/lib/project-root.sh
@@ -1,0 +1,96 @@
+#!/usr/bin/env bash
+#
+# Deterministic project-root resolver for all humanize hooks and scripts.
+#
+# Resolution priority:
+#   1. CLAUDE_PROJECT_DIR (set by Claude Code, stable across `cd` within a session)
+#   2. git rev-parse --show-toplevel (nearest enclosing repo)
+#   3. Non-zero return.
+#
+# pwd is intentionally NOT used as a fallback: it drifts with `cd`
+# invocations during a session and silently causes state.md lookups
+# under .humanize/rlcr/ to miss the active loop directory.
+#
+# The resolved path is passed through realpath so symlinked prefixes
+# (e.g. /Users/x vs /private/Users/x on macOS, or /var vs /private/var)
+# do not diverge between setup-time and hook-time resolution.
+#
+# Path-comparison sites in validators must mirror this by canonicalizing
+# the user-provided side as well; use the companion `canonicalize_path`
+# helper below.
+#
+
+if [[ -n "${_HUMANIZE_PROJECT_ROOT_SOURCED:-}" ]]; then
+    return 0 2>/dev/null || true
+fi
+_HUMANIZE_PROJECT_ROOT_SOURCED=1
+
+# resolve_project_root
+#
+# Prints the resolved project root to stdout. Returns 0 on success,
+# 1 when neither CLAUDE_PROJECT_DIR nor a git toplevel is available.
+#
+# Callers that must have a project root should handle the failure:
+#
+#   PROJECT_ROOT="$(resolve_project_root)" || exit 0   # hook: allow natural stop
+#   PROJECT_ROOT="$(resolve_project_root)" || {        # setup: hard error
+#       echo "Error: cannot determine humanize project root" >&2
+#       exit 1
+#   }
+#
+resolve_project_root() {
+    local root="${CLAUDE_PROJECT_DIR:-}"
+    if [[ -z "$root" ]]; then
+        root="$(git rev-parse --show-toplevel 2>/dev/null || true)"
+    fi
+    if [[ -z "$root" ]]; then
+        return 1
+    fi
+
+    local canonical
+    canonical=$(canonicalize_path "$root")
+    printf '%s\n' "${canonical:-$root}"
+}
+
+# canonicalize_path
+#
+# Prints the realpath of the input path. If the path itself does not
+# exist yet (common for write validation before the file is created),
+# canonicalizes the parent directory and reattaches the basename.
+# If realpath is unavailable and python3 is missing, prints the input
+# path verbatim.
+#
+# Empty input prints nothing and returns 0.
+#
+canonicalize_path() {
+    local path="$1"
+    if [[ -z "$path" ]]; then
+        return 0
+    fi
+
+    local canonical=""
+
+    if canonical=$(realpath "$path" 2>/dev/null) && [[ -n "$canonical" ]]; then
+        printf '%s\n' "$canonical"
+        return 0
+    fi
+
+    # Path does not exist: canonicalize parent, reattach basename.
+    local parent base
+    parent=$(dirname -- "$path")
+    base=$(basename -- "$path")
+    if canonical=$(realpath "$parent" 2>/dev/null) && [[ -n "$canonical" ]]; then
+        printf '%s/%s\n' "${canonical%/}" "$base"
+        return 0
+    fi
+
+    if command -v python3 >/dev/null 2>&1; then
+        canonical=$(python3 -c 'import os,sys;print(os.path.realpath(sys.argv[1]))' "$path" 2>/dev/null || true)
+        if [[ -n "$canonical" ]]; then
+            printf '%s\n' "$canonical"
+            return 0
+        fi
+    fi
+
+    printf '%s\n' "$path"
+}

--- a/hooks/loop-bash-validator.sh
+++ b/hooks/loop-bash-validator.sh
@@ -49,7 +49,7 @@ COMMAND_LOWER=$(to_lower "$COMMAND")
 # Find Active Loops (needed for multiple checks)
 # ========================================
 
-PROJECT_ROOT="${CLAUDE_PROJECT_DIR:-$(pwd)}"
+PROJECT_ROOT="$(resolve_project_root)" || exit 0
 
 # Extract session_id from hook input for session-aware loop filtering
 HOOK_SESSION_ID=$(extract_session_id "$HOOK_INPUT")

--- a/hooks/loop-codex-stop-hook.sh
+++ b/hooks/loop-codex-stop-hook.sh
@@ -39,12 +39,12 @@ HOOK_INPUT=$(cat)
 # Find Active Loop
 # ========================================
 
-PROJECT_ROOT="${CLAUDE_PROJECT_DIR:-$(pwd)}"
-LOOP_BASE_DIR="$PROJECT_ROOT/.humanize/rlcr"
-
 # Source shared loop functions and template loader
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]:-$0}")" && pwd)"
 source "$SCRIPT_DIR/lib/loop-common.sh"
+
+PROJECT_ROOT="$(resolve_project_root)" || exit 0
+LOOP_BASE_DIR="$PROJECT_ROOT/.humanize/rlcr"
 
 # Source portable timeout wrapper for git operations
 PLUGIN_ROOT="$(cd "$SCRIPT_DIR/.." && pwd)"

--- a/hooks/loop-edit-validator.sh
+++ b/hooks/loop-edit-validator.sh
@@ -38,7 +38,7 @@ HOOK_SESSION_ID=$(extract_session_id "$HOOK_INPUT")
 # ========================================
 
 if is_round_file_type "$FILE_PATH_LOWER" "todos"; then
-    PROJECT_ROOT="${CLAUDE_PROJECT_DIR:-$(pwd)}"
+    PROJECT_ROOT="$(resolve_project_root)" || exit 0
     LOOP_BASE_DIR="$PROJECT_ROOT/.humanize/rlcr"
     LOOP_DIR=$(find_active_loop "$LOOP_BASE_DIR" "$HOOK_SESSION_ID")
     if [[ -z "$LOOP_DIR" ]] || ! is_allowlisted_file "$FILE_PATH" "$LOOP_DIR"; then
@@ -59,7 +59,8 @@ fi
 # This prevents source code modifications after Codex has signed off.
 # This check MUST come before the humanize loop dir early exit below.
 
-PROJECT_ROOT="${PROJECT_ROOT:-${CLAUDE_PROJECT_DIR:-$(pwd)}}"
+PROJECT_ROOT="${PROJECT_ROOT:-$(resolve_project_root 2>/dev/null || true)}"
+[[ -z "$PROJECT_ROOT" ]] && exit 0
 LOOP_BASE_DIR="${LOOP_BASE_DIR:-$PROJECT_ROOT/.humanize/rlcr}"
 # Use only the session-matched loop. Do NOT fall back to an unfiltered search,
 # as that would incorrectly restrict unrelated sessions opened in the same repo.
@@ -124,7 +125,8 @@ fi
 # Find Active Loop and Current Round
 # ========================================
 
-PROJECT_ROOT="${PROJECT_ROOT:-${CLAUDE_PROJECT_DIR:-$(pwd)}}"
+PROJECT_ROOT="${PROJECT_ROOT:-$(resolve_project_root 2>/dev/null || true)}"
+[[ -z "$PROJECT_ROOT" ]] && exit 0
 LOOP_BASE_DIR="${LOOP_BASE_DIR:-$PROJECT_ROOT/.humanize/rlcr}"
 ACTIVE_LOOP_DIR="${LOOP_DIR:-$(find_active_loop "$LOOP_BASE_DIR" "$HOOK_SESSION_ID")}"
 

--- a/hooks/loop-plan-file-validator.sh
+++ b/hooks/loop-plan-file-validator.sh
@@ -11,10 +11,11 @@
 set -euo pipefail
 
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]:-$0}")" && pwd)"
-PROJECT_ROOT="${CLAUDE_PROJECT_DIR:-$(pwd)}"
 
 # Source shared loop functions and template loader
 source "$SCRIPT_DIR/lib/loop-common.sh"
+
+PROJECT_ROOT="$(resolve_project_root)" || exit 0
 
 # Source portable timeout wrapper for git operations
 PLUGIN_ROOT="$(cd "$SCRIPT_DIR/.." && pwd)"

--- a/hooks/loop-post-bash-hook.sh
+++ b/hooks/loop-post-bash-hook.sh
@@ -26,8 +26,13 @@ set -euo pipefail
 # Read hook JSON input from stdin
 HOOK_INPUT=$(cat)
 
-# Determine project root
-PROJECT_ROOT="${CLAUDE_PROJECT_DIR:-$(pwd)}"
+# Determine project root using the shared deterministic resolver.
+# If neither CLAUDE_PROJECT_DIR nor a git toplevel is available, there
+# is no active loop to patch - exit cleanly (pwd is NOT used as a
+# fallback because it drifts with `cd` during a session).
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]:-$0}")" && pwd)"
+source "$SCRIPT_DIR/lib/project-root.sh"
+PROJECT_ROOT="$(resolve_project_root)" || exit 0
 
 # Check for pending session_id signal file
 SIGNAL_FILE="$PROJECT_ROOT/.humanize/.pending-session-id"

--- a/hooks/loop-read-validator.sh
+++ b/hooks/loop-read-validator.sh
@@ -54,7 +54,7 @@ HOOK_SESSION_ID=$(extract_session_id "$HOOK_INPUT")
 # ========================================
 
 if is_round_file_type "$FILE_PATH_LOWER" "todos"; then
-    PROJECT_ROOT="${CLAUDE_PROJECT_DIR:-$(pwd)}"
+    PROJECT_ROOT="$(resolve_project_root)" || exit 0
     LOOP_BASE_DIR="$PROJECT_ROOT/.humanize/rlcr"
     LOOP_DIR=$(find_active_loop "$LOOP_BASE_DIR" "$HOOK_SESSION_ID")
     if [[ -z "$LOOP_DIR" ]] || ! is_allowlisted_file "$FILE_PATH" "$LOOP_DIR"; then
@@ -73,7 +73,8 @@ fi
 # This check MUST come before the summary/prompt early exit below,
 # otherwise non-summary/prompt files in the loop dir escape restriction.
 
-PROJECT_ROOT="${PROJECT_ROOT:-${CLAUDE_PROJECT_DIR:-$(pwd)}}"
+PROJECT_ROOT="${PROJECT_ROOT:-$(resolve_project_root 2>/dev/null || true)}"
+[[ -z "$PROJECT_ROOT" ]] && exit 0
 LOOP_BASE_DIR="${LOOP_BASE_DIR:-$PROJECT_ROOT/.humanize/rlcr}"
 # Use only the session-matched loop. Do NOT fall back to an unfiltered search,
 # as that would incorrectly restrict unrelated sessions opened in the same repo.
@@ -303,7 +304,11 @@ fi
 
 CORRECT_PATH="$ACTIVE_LOOP_DIR/$CLAUDE_FILENAME"
 
-if [[ "$FILE_PATH" != "$CORRECT_PATH" ]]; then
+# Compare canonical (symlink-resolved) forms -- see loop-write-validator.sh
+# for the rationale; the same reasoning applies to read paths.
+_READ_FILE_REAL=$(canonicalize_path "$FILE_PATH")
+_READ_CORRECT_REAL=$(canonicalize_path "$CORRECT_PATH")
+if [[ "${_READ_FILE_REAL:-$FILE_PATH}" != "${_READ_CORRECT_REAL:-$CORRECT_PATH}" ]]; then
     FALLBACK="# Wrong Directory Path
 
 You tried to {{ACTION}} {{FILE_PATH}} but the correct path is {{CORRECT_PATH}}"

--- a/hooks/loop-write-validator.sh
+++ b/hooks/loop-write-validator.sh
@@ -55,7 +55,7 @@ HOOK_SESSION_ID=$(extract_session_id "$HOOK_INPUT")
 # ========================================
 
 if is_round_file_type "$FILE_PATH_LOWER" "todos"; then
-    PROJECT_ROOT="${CLAUDE_PROJECT_DIR:-$(pwd)}"
+    PROJECT_ROOT="$(resolve_project_root)" || exit 0
     LOOP_BASE_DIR="$PROJECT_ROOT/.humanize/rlcr"
     LOOP_DIR=$(find_active_loop "$LOOP_BASE_DIR" "$HOOK_SESSION_ID")
     if [[ -z "$LOOP_DIR" ]] || ! is_allowlisted_file "$FILE_PATH" "$LOOP_DIR"; then
@@ -76,7 +76,8 @@ fi
 # This prevents source code modifications after Codex has signed off.
 # This check MUST come before the file type early exits below.
 
-PROJECT_ROOT="${PROJECT_ROOT:-${CLAUDE_PROJECT_DIR:-$(pwd)}}"
+PROJECT_ROOT="${PROJECT_ROOT:-$(resolve_project_root 2>/dev/null || true)}"
+[[ -z "$PROJECT_ROOT" ]] && exit 0
 LOOP_BASE_DIR="${LOOP_BASE_DIR:-$PROJECT_ROOT/.humanize/rlcr}"
 # Use only the session-matched loop. Do NOT fall back to an unfiltered search,
 # as that would incorrectly restrict unrelated sessions opened in the same repo.
@@ -160,7 +161,8 @@ fi
 # ========================================
 
 # Re-initialize if not set by earlier todos check
-PROJECT_ROOT="${PROJECT_ROOT:-${CLAUDE_PROJECT_DIR:-$(pwd)}}"
+PROJECT_ROOT="${PROJECT_ROOT:-$(resolve_project_root 2>/dev/null || true)}"
+[[ -z "$PROJECT_ROOT" ]] && exit 0
 LOOP_BASE_DIR="${LOOP_BASE_DIR:-$PROJECT_ROOT/.humanize/rlcr}"
 ACTIVE_LOOP_DIR="${LOOP_DIR:-$(find_active_loop "$LOOP_BASE_DIR" "$HOOK_SESSION_ID")}"
 
@@ -329,7 +331,14 @@ fi
 
 CORRECT_PATH="$ACTIVE_LOOP_DIR/$CLAUDE_FILENAME"
 
-if [[ "$FILE_PATH" != "$CORRECT_PATH" ]]; then
+# Compare canonical (symlink-resolved) forms so the check is not fooled by
+# equivalent paths expressed in different prefix forms (e.g. /var/... vs
+# /private/var/... on macOS). A raw string compare would mis-handle a
+# symlinked project prefix whenever one side was canonicalized upstream
+# (e.g. by resolve_project_root) and the other was not.
+_WRITE_FILE_REAL=$(canonicalize_path "$FILE_PATH")
+_WRITE_CORRECT_REAL=$(canonicalize_path "$CORRECT_PATH")
+if [[ "${_WRITE_FILE_REAL:-$FILE_PATH}" != "${_WRITE_CORRECT_REAL:-$CORRECT_PATH}" ]]; then
     FALLBACK="# Wrong Directory Path
 
 You tried to {{ACTION}} {{FILE_PATH}} but the correct path is {{CORRECT_PATH}}"

--- a/scripts/ask-codex.sh
+++ b/scripts/ask-codex.sh
@@ -189,11 +189,11 @@ fi
 # Detect Project Root
 # ========================================
 
-if git rev-parse --show-toplevel &>/dev/null; then
-    PROJECT_ROOT=$(git rev-parse --show-toplevel)
-else
-    PROJECT_ROOT="${CLAUDE_PROJECT_DIR:-$(pwd)}"
-fi
+PROJECT_ROOT="$(resolve_project_root)" || {
+    echo "Error: Cannot determine project root." >&2
+    echo "  Set CLAUDE_PROJECT_DIR or run inside a git repository." >&2
+    exit 1
+}
 
 # ========================================
 # Create Storage Directories

--- a/scripts/ask-gemini.sh
+++ b/scripts/ask-gemini.sh
@@ -29,6 +29,9 @@ SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]:-$0}")" && pwd)"
 # Source portable timeout wrapper
 source "$SCRIPT_DIR/portable-timeout.sh"
 
+# Shared project-root resolver (CLAUDE_PROJECT_DIR -> git toplevel, realpath-canonical)
+source "$SCRIPT_DIR/../hooks/lib/project-root.sh"
+
 # ========================================
 # Default Configuration
 # ========================================
@@ -168,11 +171,11 @@ fi
 # Detect Project Root
 # ========================================
 
-if git rev-parse --show-toplevel &>/dev/null; then
-    PROJECT_ROOT=$(git rev-parse --show-toplevel)
-else
-    PROJECT_ROOT="${CLAUDE_PROJECT_DIR:-$(pwd)}"
-fi
+PROJECT_ROOT="$(resolve_project_root)" || {
+    echo "Error: Cannot determine project root." >&2
+    echo "  Set CLAUDE_PROJECT_DIR or run inside a git repository." >&2
+    exit 1
+}
 
 # ========================================
 # Create Storage Directories

--- a/scripts/bitlesson-select.sh
+++ b/scripts/bitlesson-select.sh
@@ -9,9 +9,14 @@ set -euo pipefail
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]:-$0}")" && pwd)"
 source "$SCRIPT_DIR/lib/config-loader.sh"
 source "$SCRIPT_DIR/lib/model-router.sh"
+source "$SCRIPT_DIR/../hooks/lib/project-root.sh"
 
 PLUGIN_ROOT="$(cd "$SCRIPT_DIR/.." && pwd)"
-PROJECT_ROOT="${CLAUDE_PROJECT_DIR:-$(git rev-parse --show-toplevel 2>/dev/null || pwd)}"
+PROJECT_ROOT="$(resolve_project_root)" || {
+    echo "Error: Cannot determine project root." >&2
+    echo "  Set CLAUDE_PROJECT_DIR or run inside a git repository." >&2
+    exit 1
+}
 MERGED_CONFIG="$(load_merged_config "$PLUGIN_ROOT" "$PROJECT_ROOT")"
 BITLESSON_MODEL="$(get_config_value "$MERGED_CONFIG" "bitlesson_model")"
 BITLESSON_MODEL="${BITLESSON_MODEL:-haiku}"

--- a/scripts/cancel-rlcr-loop.sh
+++ b/scripts/cancel-rlcr-loop.sh
@@ -66,12 +66,16 @@ done
 # Find Loop Directory
 # ========================================
 
-PROJECT_ROOT="${CLAUDE_PROJECT_DIR:-$(pwd)}"
-LOOP_BASE_DIR="$PROJECT_ROOT/.humanize/rlcr"
-
-# Source shared loop library for find_active_loop
+# Source shared loop library for find_active_loop and resolve_project_root
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]:-$0}")" && pwd)"
 source "$SCRIPT_DIR/../hooks/lib/loop-common.sh"
+
+PROJECT_ROOT="$(resolve_project_root)" || {
+    echo "Error: Cannot determine humanize project root." >&2
+    echo "  Set CLAUDE_PROJECT_DIR or run inside a git repository." >&2
+    exit 3
+}
+LOOP_BASE_DIR="$PROJECT_ROOT/.humanize/rlcr"
 
 # PRODUCT DECISION: Cancel operates globally (no session_id filtering).
 #

--- a/scripts/rlcr-stop-gate.sh
+++ b/scripts/rlcr-stop-gate.sh
@@ -18,7 +18,12 @@ set -euo pipefail
 
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]:-$0}")" && pwd)"
 HUMANIZE_ROOT="$(cd "$SCRIPT_DIR/.." && pwd)"
-PROJECT_ROOT="${CLAUDE_PROJECT_DIR:-$(pwd)}"
+
+# Deterministic project-root resolver (CLAUDE_PROJECT_DIR -> git toplevel, no pwd fallback).
+# Overridable via --project-root for non-hook callers; the flag handler below
+# always wins because it runs after this default assignment.
+source "$HUMANIZE_ROOT/hooks/lib/project-root.sh"
+PROJECT_ROOT="$(resolve_project_root 2>/dev/null || true)"
 HOOK_SCRIPT="$HUMANIZE_ROOT/hooks/loop-codex-stop-hook.sh"
 
 SESSION_ID="${CLAUDE_SESSION_ID:-}"
@@ -72,6 +77,14 @@ while [[ $# -gt 0 ]]; do
             ;;
     esac
 done
+
+if [[ -z "$PROJECT_ROOT" ]]; then
+    # No humanize project context reachable from here -- nothing to enforce.
+    # Allow the stop to proceed instead of returning a wrapper error so that
+    # invoking the gate outside any project (or any git repo) is benign.
+    echo "ALLOW: no humanize project root resolved."
+    exit 0
+fi
 
 if [[ ! -x "$HOOK_SCRIPT" ]]; then
     echo "Error: Hook script not found or not executable: $HOOK_SCRIPT" >&2

--- a/scripts/setup-rlcr-loop.sh
+++ b/scripts/setup-rlcr-loop.sh
@@ -323,7 +323,11 @@ done
 # Validate Prerequisites
 # ========================================
 
-PROJECT_ROOT="${CLAUDE_PROJECT_DIR:-$(pwd)}"
+PROJECT_ROOT="$(resolve_project_root)" || {
+    echo "Error: Cannot determine humanize project root." >&2
+    echo "  Set CLAUDE_PROJECT_DIR or run inside a git repository." >&2
+    exit 1
+}
 
 # loop-common.sh already sourced above (provides find_active_loop, etc.)
 

--- a/tests/test-cancel-signal-file.sh
+++ b/tests/test-cancel-signal-file.sh
@@ -1342,6 +1342,37 @@ else
     pass "is_cancel_authorized rejects hidden variables"
 fi
 
+echo "HELPER TEST 8: is_cancel_authorized accepts symlinked-prefix path"
+# Regression test: when the user supplies the active-loop path through a
+# symlinked prefix (e.g. /var/... on macOS resolves to /private/var/...),
+# the authorization check must canonicalize both sides so it still matches.
+# We simulate the scenario by creating an all-lowercase sibling layout
+# (mktemp dirs contain mixed case, which would defeat realpath once the
+# command is lowercased on case-sensitive filesystems), then symlinking
+# from there back to the real loop dir.
+setup_test_loop "helper-8"
+touch "$LOOP_DIR/.cancel-requested"
+
+SYMLINK_ROOT=$(mktemp -d "${TMPDIR:-/tmp}/humanize-symlink-XXXXXXXX" | tr '[:upper:]' '[:lower:]')
+# mktemp already lowercases when we pipe it; re-run if the resulting dir does
+# not actually exist (shouldn't happen but defensive for portability).
+[[ -d "$SYMLINK_ROOT" ]] || { rm -rf "$SYMLINK_ROOT" 2>/dev/null; SYMLINK_ROOT="${TMPDIR:-/tmp}/humanize-symlink-lowercase-$$"; mkdir -p "$SYMLINK_ROOT"; }
+
+SYMLINK_LOOP_DIR="$SYMLINK_ROOT/via-symlink"
+ln -sfn "$LOOP_DIR" "$SYMLINK_LOOP_DIR"
+
+CANONICAL_LOOP_DIR="$(cd "$LOOP_DIR" && pwd -P)"
+COMMAND_LOWER="mv ${SYMLINK_LOOP_DIR}/state.md ${SYMLINK_LOOP_DIR}/cancel-state.md"
+COMMAND_LOWER=$(to_lower "$COMMAND_LOWER")
+
+if is_cancel_authorized "$CANONICAL_LOOP_DIR" "$COMMAND_LOWER"; then
+    pass "is_cancel_authorized accepts symlinked-prefix path after realpath"
+else
+    fail "helper symlink prefix" "returns 0 (authorized)" "returns non-zero"
+fi
+
+rm -rf "$SYMLINK_ROOT" 2>/dev/null || true
+
 # ========================================
 # Summary
 # ========================================

--- a/tests/test-stop-gate.sh
+++ b/tests/test-stop-gate.sh
@@ -231,9 +231,12 @@ chmod +x "$T6_DIR/bin/loop-codex-stop-hook.sh"
 # Layout expected by rlcr-stop-gate.sh: HUMANIZE_ROOT/hooks/loop-codex-stop-hook.sh.
 # We stage a fake plugin root pointing at the mock hook and copy the gate
 # wrapper next to it so the relative resolution resolves to the mock.
-mkdir -p "$T6_DIR/plugin/scripts" "$T6_DIR/plugin/hooks"
+mkdir -p "$T6_DIR/plugin/scripts" "$T6_DIR/plugin/hooks/lib"
 cp "$T6_DIR/bin/loop-codex-stop-hook.sh" "$T6_DIR/plugin/hooks/loop-codex-stop-hook.sh"
 cp "$GATE_SCRIPT" "$T6_DIR/plugin/scripts/rlcr-stop-gate.sh"
+# rlcr-stop-gate sources hooks/lib/project-root.sh for PROJECT_ROOT resolution.
+REAL_PROJECT_ROOT_LIB="$(dirname "$GATE_SCRIPT")/../hooks/lib/project-root.sh"
+cp "$REAL_PROJECT_ROOT_LIB" "$T6_DIR/plugin/hooks/lib/project-root.sh"
 chmod +x "$T6_DIR/plugin/scripts/rlcr-stop-gate.sh"
 
 T6_INPUT_LOG="$T6_DIR/hook-input.json"
@@ -243,6 +246,11 @@ T6_TRANSCRIPT="$T6_DIR/fake-transcript.jsonl"
 set +e
 (
     cd "$T6_DIR"
+    # Pin CLAUDE_PROJECT_DIR so rlcr-stop-gate resolves a root even though
+    # the fixture is not a git repo. This test exercises the JSON-object-
+    # collapse regression for empty session_id; project-root resolution is
+    # orthogonal and must not short-circuit the gate with an ALLOW.
+    CLAUDE_PROJECT_DIR="$T6_DIR" \
     MOCK_HOOK_INPUT_LOG="$T6_INPUT_LOG" \
     "$T6_DIR/plugin/scripts/rlcr-stop-gate.sh" \
         --transcript-path "$T6_TRANSCRIPT" \


### PR DESCRIPTION
## Summary
- Introduce a shared `resolve_project_root` helper in `hooks/lib/project-root.sh` and route every hook and script through it. The resolver prefers `CLAUDE_PROJECT_DIR`, falls back to `git rev-parse --show-toplevel`, and refuses the legacy `pwd` fallback (which drifts with `cd` during a session and silently caused state lookups to miss the active loop directory).
- Canonicalize the resolved path through `realpath` so symlinked ancestors (e.g. `/var/...` vs `/private/var/...` on macOS, or a symlinked repo checkout on Linux) do not diverge between setup time and hook time.
- Mirror the canonicalization on every path-comparison site that consumes `PROJECT_ROOT`: `loop-read-validator.sh`, `loop-write-validator.sh`, and `is_cancel_authorized` in `hooks/lib/loop-common.sh`. `is_cancel_authorized` now canonicalizes both the loop dir and the parsed `mv` source/destination, then re-lowercases so the comparison stays symmetric on case-insensitive filesystems.
- Guard the merged-config load in `loop-common.sh` so sourcing `humanize.sh` from `.bashrc`/`.zshrc` in a non-repo directory no longer emits `Error: Usage: load_merged_config <plugin_root> <project_root>` to stderr on every shell startup.

## Test plan
- [x] `bash tests/run-all-tests.sh` -> 1723 passed / 0 failed
- [x] New regression test `HELPER TEST 8` in `tests/test-cancel-signal-file.sh` covers a symlinked-prefix cancel command against a canonical loop dir
- [x] New stop-gate fixture in `tests/test-stop-gate.sh` stages `hooks/lib/project-root.sh` alongside the mock hook so the wrapper resolves a project root
- [ ] Manual: source `scripts/humanize.sh` from `$HOME` (non-repo, no `CLAUDE_PROJECT_DIR`) and confirm no usage error is printed