### PR TITLE
Fix Windows hook dispatch via explicit bash invocation

### DIFF
--- a/hooks/hooks.json
+++ b/hooks/hooks.json
@@ -6,7 +6,7 @@
         "hooks": [
           {
             "type": "command",
-            "command": "${CLAUDE_PLUGIN_ROOT}/hooks/loop-plan-file-validator.sh"
+            "command": "bash \"${CLAUDE_PLUGIN_ROOT}/hooks/loop-plan-file-validator.sh\""
           }
         ]
       }
@@ -17,7 +17,7 @@
         "hooks": [
           {
             "type": "command",
-            "command": "${CLAUDE_PLUGIN_ROOT}/hooks/loop-write-validator.sh"
+            "command": "bash \"${CLAUDE_PLUGIN_ROOT}/hooks/loop-write-validator.sh\""
           }
         ]
       },
@@ -26,7 +26,7 @@
         "hooks": [
           {
             "type": "command",
-            "command": "${CLAUDE_PLUGIN_ROOT}/hooks/loop-edit-validator.sh"
+            "command": "bash \"${CLAUDE_PLUGIN_ROOT}/hooks/loop-edit-validator.sh\""
           }
         ]
       },
@@ -35,7 +35,7 @@
         "hooks": [
           {
             "type": "command",
-            "command": "${CLAUDE_PLUGIN_ROOT}/hooks/loop-read-validator.sh"
+            "command": "bash \"${CLAUDE_PLUGIN_ROOT}/hooks/loop-read-validator.sh\""
           }
         ]
       },
@@ -44,7 +44,7 @@
         "hooks": [
           {
             "type": "command",
-            "command": "${CLAUDE_PLUGIN_ROOT}/hooks/loop-bash-validator.sh"
+            "command": "bash \"${CLAUDE_PLUGIN_ROOT}/hooks/loop-bash-validator.sh\""
           }
         ]
       }
@@ -55,7 +55,7 @@
         "hooks": [
           {
             "type": "command",
-            "command": "${CLAUDE_PLUGIN_ROOT}/hooks/loop-post-bash-hook.sh"
+            "command": "bash \"${CLAUDE_PLUGIN_ROOT}/hooks/loop-post-bash-hook.sh\""
           }
         ]
       }
@@ -65,7 +65,7 @@
         "hooks": [
           {
             "type": "command",
-            "command": "${CLAUDE_PLUGIN_ROOT}/hooks/loop-codex-stop-hook.sh",
+            "command": "bash \"${CLAUDE_PLUGIN_ROOT}/hooks/loop-codex-stop-hook.sh\"",
             "timeout": 7200
           }
         ]

--- a/hooks/lib/loop-common.sh
+++ b/hooks/lib/loop-common.sh
@@ -792,6 +792,12 @@ to_lower() {
     echo "$1" | tr '[:upper:]' '[:lower:]'
 }
 
+# Normalize Windows path separators to the POSIX-style separators used by the
+# hook validators' string patterns.
+normalize_path_separators() {
+    echo "${1//\\//}"
+}
+
 # Check if a path (lowercase) matches a round file pattern
 # Usage: is_round_file "$lowercase_path" "summary|prompt|todos|contract"
 is_round_file_type() {
@@ -1252,7 +1258,7 @@ is_cancel_authorized() {
 # Check if a path is inside .humanize/rlcr directory
 is_in_humanize_loop_dir() {
     local path="$1"
-    echo "$path" | grep -q '\.humanize/rlcr/'
+    normalize_path_separators "$path" | grep -q '\.humanize/rlcr/'
 }
 
 # Check if a git add command would add .humanize files to version control

--- a/hooks/loop-edit-validator.sh
+++ b/hooks/loop-edit-validator.sh
@@ -28,6 +28,7 @@ if [[ "$TOOL_NAME" != "Edit" ]]; then
 fi
 
 FILE_PATH=$(echo "$HOOK_INPUT" | jq -r '.tool_input.file_path // ""')
+FILE_PATH=$(normalize_path_separators "$FILE_PATH")
 FILE_PATH_LOWER=$(to_lower "$FILE_PATH")
 
 # Extract session_id from hook input for session-aware loop filtering

--- a/hooks/loop-read-validator.sh
+++ b/hooks/loop-read-validator.sh
@@ -44,6 +44,7 @@ if ! require_tool_input_field "$HOOK_INPUT" "file_path"; then
 fi
 
 FILE_PATH=$(echo "$HOOK_INPUT" | jq -r '.tool_input.file_path // ""')
+FILE_PATH=$(normalize_path_separators "$FILE_PATH")
 FILE_PATH_LOWER=$(to_lower "$FILE_PATH")
 
 # Extract session_id from hook input for session-aware loop filtering

--- a/hooks/loop-write-validator.sh
+++ b/hooks/loop-write-validator.sh
@@ -45,6 +45,7 @@ if ! require_tool_input_field "$HOOK_INPUT" "file_path"; then
 fi
 
 FILE_PATH=$(echo "$HOOK_INPUT" | jq -r '.tool_input.file_path // ""')
+FILE_PATH=$(normalize_path_separators "$FILE_PATH")
 FILE_PATH_LOWER=$(to_lower "$FILE_PATH")
 
 # Extract session_id from hook input for session-aware loop filtering

--- a/tests/test-allowlist-validators.sh
+++ b/tests/test-allowlist-validators.sh
@@ -218,6 +218,50 @@ else
     fail "Write validator round-3-contract.md" "exit 2 with round error" "exit $EXIT_CODE, output: $RESULT"
 fi
 
+WINDOWS_LOOP_DIR="${LOOP_DIR//\//\\}"
+
+# Test 11c: Write validator blocks stale summary with Windows separators
+echo "Test 11c: Write validator blocks Windows-path round-3-summary.md"
+WINDOWS_FILE_PATH="${WINDOWS_LOOP_DIR}\\round-3-summary.md"
+HOOK_INPUT=$(jq -nc --arg file_path "$WINDOWS_FILE_PATH" '{tool_name: "Write", tool_input: {file_path: $file_path}}')
+set +e
+RESULT=$(echo "$HOOK_INPUT" | "$PROJECT_ROOT/hooks/loop-write-validator.sh" 2>&1)
+EXIT_CODE=$?
+set -e
+if [[ $EXIT_CODE -eq 2 ]] && echo "$RESULT" | grep -qi "round"; then
+    pass "Write validator blocks Windows-path round-3-summary.md"
+else
+    fail "Write validator Windows-path round-3-summary.md" "exit 2 with round error" "exit $EXIT_CODE, output: $RESULT"
+fi
+
+# Test 11d: Write validator allows current summary with Windows separators
+echo "Test 11d: Write validator allows Windows-path round-5-summary.md"
+WINDOWS_FILE_PATH="${WINDOWS_LOOP_DIR}\\round-5-summary.md"
+HOOK_INPUT=$(jq -nc --arg file_path "$WINDOWS_FILE_PATH" '{tool_name: "Write", tool_input: {file_path: $file_path}}')
+set +e
+RESULT=$(echo "$HOOK_INPUT" | "$PROJECT_ROOT/hooks/loop-write-validator.sh" 2>&1)
+EXIT_CODE=$?
+set -e
+if [[ $EXIT_CODE -eq 0 ]]; then
+    pass "Write validator allows Windows-path round-5-summary.md"
+else
+    fail "Write validator Windows-path round-5-summary.md" "exit 0" "exit $EXIT_CODE, output: $RESULT"
+fi
+
+# Test 11e: Write validator blocks plan.md backup with Windows separators
+echo "Test 11e: Write validator blocks Windows-path plan.md backup"
+WINDOWS_FILE_PATH="${WINDOWS_LOOP_DIR}\\plan.md"
+HOOK_INPUT=$(jq -nc --arg file_path "$WINDOWS_FILE_PATH" '{tool_name: "Write", tool_input: {file_path: $file_path}}')
+set +e
+RESULT=$(echo "$HOOK_INPUT" | "$PROJECT_ROOT/hooks/loop-write-validator.sh" 2>&1)
+EXIT_CODE=$?
+set -e
+if [[ $EXIT_CODE -eq 2 ]] && echo "$RESULT" | grep -qi "plan"; then
+    pass "Write validator blocks Windows-path plan.md backup"
+else
+    fail "Write validator Windows-path plan.md backup" "exit 2 with plan error" "exit $EXIT_CODE, output: $RESULT"
+fi
+
 echo ""
 echo "=== Test: Edit Validator Allowlist ==="
 echo ""
@@ -272,6 +316,48 @@ if [[ $EXIT_CODE -eq 2 ]] && echo "$RESULT" | grep -qi "round"; then
     pass "Edit validator blocks round-0-contract.md"
 else
     fail "Edit validator round-0-contract.md" "exit 2 with round error" "exit $EXIT_CODE, output: $RESULT"
+fi
+
+# Test 13d: Edit validator blocks stale summary with Windows separators
+echo "Test 13d: Edit validator blocks Windows-path round-3-summary.md"
+WINDOWS_FILE_PATH="${WINDOWS_LOOP_DIR}\\round-3-summary.md"
+HOOK_INPUT=$(jq -nc --arg file_path "$WINDOWS_FILE_PATH" '{tool_name: "Edit", tool_input: {file_path: $file_path}}')
+set +e
+RESULT=$(echo "$HOOK_INPUT" | "$PROJECT_ROOT/hooks/loop-edit-validator.sh" 2>&1)
+EXIT_CODE=$?
+set -e
+if [[ $EXIT_CODE -eq 2 ]] && echo "$RESULT" | grep -qi "round"; then
+    pass "Edit validator blocks Windows-path round-3-summary.md"
+else
+    fail "Edit validator Windows-path round-3-summary.md" "exit 2 with round error" "exit $EXIT_CODE, output: $RESULT"
+fi
+
+# Test 13e: Edit validator allows current summary with Windows separators
+echo "Test 13e: Edit validator allows Windows-path round-5-summary.md"
+WINDOWS_FILE_PATH="${WINDOWS_LOOP_DIR}\\round-5-summary.md"
+HOOK_INPUT=$(jq -nc --arg file_path "$WINDOWS_FILE_PATH" '{tool_name: "Edit", tool_input: {file_path: $file_path}}')
+set +e
+RESULT=$(echo "$HOOK_INPUT" | "$PROJECT_ROOT/hooks/loop-edit-validator.sh" 2>&1)
+EXIT_CODE=$?
+set -e
+if [[ $EXIT_CODE -eq 0 ]]; then
+    pass "Edit validator allows Windows-path round-5-summary.md"
+else
+    fail "Edit validator Windows-path round-5-summary.md" "exit 0" "exit $EXIT_CODE, output: $RESULT"
+fi
+
+# Test 13f: Edit validator blocks plan.md backup with Windows separators
+echo "Test 13f: Edit validator blocks Windows-path plan.md backup"
+WINDOWS_FILE_PATH="${WINDOWS_LOOP_DIR}\\plan.md"
+HOOK_INPUT=$(jq -nc --arg file_path "$WINDOWS_FILE_PATH" '{tool_name: "Edit", tool_input: {file_path: $file_path}}')
+set +e
+RESULT=$(echo "$HOOK_INPUT" | "$PROJECT_ROOT/hooks/loop-edit-validator.sh" 2>&1)
+EXIT_CODE=$?
+set -e
+if [[ $EXIT_CODE -eq 2 ]] && echo "$RESULT" | grep -qi "plan"; then
+    pass "Edit validator blocks Windows-path plan.md backup"
+else
+    fail "Edit validator Windows-path plan.md backup" "exit 2 with plan error" "exit $EXIT_CODE, output: $RESULT"
 fi
 
 # Test 14: Edit validator blocks round-4-todos.md
@@ -367,6 +453,34 @@ if [[ $EXIT_CODE -eq 2 ]] && echo "$RESULT" | grep -qi "round"; then
     pass "Read validator blocks round-3-contract.md"
 else
     fail "Read validator round-3-contract.md" "exit 2 with round error" "exit $EXIT_CODE, output: $RESULT"
+fi
+
+# Test 18c: Read validator blocks stale summary with Windows separators
+echo "Test 18c: Read validator blocks Windows-path round-3-summary.md"
+WINDOWS_FILE_PATH="${WINDOWS_LOOP_DIR}\\round-3-summary.md"
+HOOK_INPUT=$(jq -nc --arg file_path "$WINDOWS_FILE_PATH" '{tool_name: "Read", tool_input: {file_path: $file_path}}')
+set +e
+RESULT=$(echo "$HOOK_INPUT" | "$PROJECT_ROOT/hooks/loop-read-validator.sh" 2>&1)
+EXIT_CODE=$?
+set -e
+if [[ $EXIT_CODE -eq 2 ]] && echo "$RESULT" | grep -qi "round"; then
+    pass "Read validator blocks Windows-path round-3-summary.md"
+else
+    fail "Read validator Windows-path round-3-summary.md" "exit 2 with round error" "exit $EXIT_CODE, output: $RESULT"
+fi
+
+# Test 18d: Read validator allows current contract with Windows separators
+echo "Test 18d: Read validator allows Windows-path round-5-contract.md"
+WINDOWS_FILE_PATH="${WINDOWS_LOOP_DIR}\\round-5-contract.md"
+HOOK_INPUT=$(jq -nc --arg file_path "$WINDOWS_FILE_PATH" '{tool_name: "Read", tool_input: {file_path: $file_path}}')
+set +e
+RESULT=$(echo "$HOOK_INPUT" | "$PROJECT_ROOT/hooks/loop-read-validator.sh" 2>&1)
+EXIT_CODE=$?
+set -e
+if [[ $EXIT_CODE -eq 0 ]]; then
+    pass "Read validator allows Windows-path round-5-contract.md"
+else
+    fail "Read validator Windows-path round-5-contract.md" "exit 0" "exit $EXIT_CODE, output: $RESULT"
 fi
 
 echo ""


### PR DESCRIPTION
## Problem

GitHub Copilot CLI on Windows installs plugin hooks under `~/.copilot/installed-plugins/<owner>/<plugin>/hooks/` and dispatches each `hooks.json` entry's `command` field through PowerShell. With the existing bare-path form (`${CLAUDE_PLUGIN_ROOT}/hooks/<name>.sh`), Windows dispatches the `.sh` file through file association instead of executing it. The visible symptom is that hook source files open as editor tabs and the hooks never fire.

This makes Humanize unusable under Copilot CLI on Windows even though the hook scripts themselves are host-agnostic.

## Fix

Switch each hook entry's `command` from a bare script path to an explicit bash invocation:

```diff
- "command": "${CLAUDE_PLUGIN_ROOT}/hooks/loop-bash-validator.sh"
+ "command": "bash \"${CLAUDE_PLUGIN_ROOT}/hooks/loop-bash-validator.sh\""
```

On Windows this resolves `bash` from `PATH` (for example Git for Windows' `bash.exe`) and passes the `.sh` file as an argument instead of letting Windows file association handle it. On macOS/Linux this preserves the same effective execution path as the existing shebang-based script dispatch.

## Windows path normalization

Windows hook payloads can carry native backslash paths such as `C:\repo\.humanize\rlcr\<loop>\round-99-summary.md`. The validators previously matched `.humanize/rlcr/` and extracted loop-relative filenames with forward-slash-only patterns, so Windows paths could be misclassified or skip round-number enforcement.

This PR normalizes path separators before read/write/edit validator path checks. That keeps all existing POSIX behavior while ensuring Windows paths still:

- match `.humanize/rlcr/`
- extract `round-*-summary.md` / `round-*-contract.md`
- enforce current-round checks
- block protected `plan.md` backups inside loop directories

## Why not the `windows:` platform-override field?

An earlier iteration tried a `windows` platform override based on VS Code Agent Hooks documentation. Empirical testing on Copilot CLI showed plugin-loaded hooks follow Claude Code's nested matcher/hooks structure and do not honor that field. The fix therefore needs to live directly in the `command` value.

## Validation

- `bash tests/test-allowlist-validators.sh`
  - 55 passing tests
  - includes Windows-backslash regression coverage for Write, Edit, and Read validators
- Bash syntax check for all `.sh` files
- `git diff --check upstream/dev...HEAD`
- JSON parse checks for `hooks/hooks.json`, `.claude-plugin/plugin.json`, and `.claude-plugin/marketplace.json`

I also attempted the requested retarget to `beta`, but GitHub rejected it because `PolyArch/humanize` has no `beta` base branch. The PR is retargeted to `dev`, which matches the repository's PR target-branch workflow.

## Scope

- 6 files touched
- No new dependencies
- Version files are intentionally unchanged at `1.17.0` because this PR now targets `dev`; the main-branch version bump workflow only applies to PRs targeting `main`.
