### PR TITLE
Fix Codex review base prompt compatibility

### DIFF
--- a/hooks/lib/template-loader.sh
+++ b/hooks/lib/template-loader.sh
@@ -70,7 +70,7 @@ render_template() {
     # Scans for {{VAR}} patterns and replaces them with values from environment
     # Replaced content goes directly to output without re-scanning
     local awk_exit=0
-    content=$(env "${env_vars[@]}" awk '
+    content=$(env ${env_vars[@]+"${env_vars[@]}"} awk '
     BEGIN {
         # Build lookup table from environment variables with TMPL_VAR_ prefix
         for (name in ENVIRON) {

--- a/hooks/loop-codex-stop-hook.sh
+++ b/hooks/loop-codex-stop-hook.sh
@@ -1228,6 +1228,8 @@ run_codex_code_review() {
     local prompt_fallback="# Code Review Phase - Round ${round}
 
 This file documents the code review invocation for audit purposes.
+Compatibility note: Codex 0.130.0 rejects [PROMPT] input, including - stdin, when --base is used.
+Humanize must not pass prompt input when --base is used; this file is audit-only.
 Provider: codex
 
 ## Review Configuration
@@ -1256,14 +1258,14 @@ Provider: codex
         echo "# Review base ($review_base_type): $review_base"
         echo "# Timeout: $CODEX_TIMEOUT seconds"
         echo ""
-        echo "codex review ${CODEX_DISABLE_HOOKS_ARGS[*]} --base $review_base ${CODEX_REVIEW_ARGS[*]}"
+        echo "codex review ${CODEX_DISABLE_HOOKS_ARGS[*]-} --base $review_base ${CODEX_REVIEW_ARGS[*]}"
     } > "$CODEX_REVIEW_CMD_FILE"
 
     echo "Code review command saved to: $CODEX_REVIEW_CMD_FILE" >&2
     echo "Running codex review with timeout ${CODEX_TIMEOUT}s in $PROJECT_ROOT (base: $review_base)..." >&2
 
     CODEX_REVIEW_EXIT_CODE=0
-    (cd "$PROJECT_ROOT" && run_with_timeout "$CODEX_TIMEOUT" codex review "${CODEX_DISABLE_HOOKS_ARGS[@]}" --base "$review_base" "${CODEX_REVIEW_ARGS[@]}") \
+    (cd "$PROJECT_ROOT" && run_with_timeout "$CODEX_TIMEOUT" codex review ${CODEX_DISABLE_HOOKS_ARGS[@]+"${CODEX_DISABLE_HOOKS_ARGS[@]}"} --base "$review_base" "${CODEX_REVIEW_ARGS[@]}") \
         > "$CODEX_REVIEW_LOG_FILE" 2>&1 || CODEX_REVIEW_EXIT_CODE=$?
 
     echo "Code review exit code: $CODEX_REVIEW_EXIT_CODE" >&2
@@ -1682,7 +1684,7 @@ CODEX_PROMPT_CONTENT=$(cat "$REVIEW_PROMPT_FILE")
     echo "# Working directory: $PROJECT_ROOT"
     echo "# Timeout: $CODEX_TIMEOUT seconds"
     echo ""
-    echo "codex exec ${CODEX_DISABLE_HOOKS_ARGS[*]} ${CODEX_EXEC_ARGS[*]} \"<prompt>\""
+    echo "codex exec ${CODEX_DISABLE_HOOKS_ARGS[*]-} ${CODEX_EXEC_ARGS[*]} \"<prompt>\""
     echo ""
     echo "# Prompt content:"
     echo "$CODEX_PROMPT_CONTENT"
@@ -1692,7 +1694,7 @@ echo "Codex command saved to: $CODEX_CMD_FILE" >&2
 echo "Running summary review with timeout ${CODEX_TIMEOUT}s..." >&2
 
 CODEX_EXIT_CODE=0
-printf '%s' "$CODEX_PROMPT_CONTENT" | run_with_timeout "$CODEX_TIMEOUT" codex exec "${CODEX_DISABLE_HOOKS_ARGS[@]}" "${CODEX_EXEC_ARGS[@]}" - \
+printf '%s' "$CODEX_PROMPT_CONTENT" | run_with_timeout "$CODEX_TIMEOUT" codex exec ${CODEX_DISABLE_HOOKS_ARGS[@]+"${CODEX_DISABLE_HOOKS_ARGS[@]}"} "${CODEX_EXEC_ARGS[@]}" - \
     > "$CODEX_STDOUT_FILE" 2> "$CODEX_STDERR_FILE" || CODEX_EXIT_CODE=$?
 
 echo "Codex exit code: $CODEX_EXIT_CODE" >&2

--- a/prompt-template/codex/code-review-phase.md
+++ b/prompt-template/codex/code-review-phase.md
@@ -1,7 +1,7 @@
 # Code Review Phase - Round {{REVIEW_ROUND}}
 
 This file documents the code review invocation for audit purposes.
-Note: `codex review` does not accept prompt input; it performs automated code review based on git diff.
+Compatibility note: Codex 0.130.0 rejects `[PROMPT]` input, including `-` stdin, when `--base` is used. Humanize must not pass prompt input when `--base` is used; this file is audit-only.
 
 ## Review Configuration
 

--- a/tests/test-disable-nested-codex-hooks.sh
+++ b/tests/test-disable-nested-codex-hooks.sh
@@ -112,7 +112,7 @@ if [[ "\$subcommand" == "review" ]]; then
         echo "codex 0.130.0 rejects --base with prompt input" >&2
         exit 64
     fi
-    if IFS= read -r stdin_line; then
+    if IFS= read -r stdin_line || [[ -n "\$stdin_line" ]]; then
         printf 'STDIN:%s\n' "\$stdin_line" >> "$args_file"
         echo "codex review must not receive stdin when --base is used" >&2
         exit 65
@@ -231,7 +231,10 @@ else
         "--base arguments with no trailing '-' and no stdin" "$(cat "$TEST_DIR/review.args" 2>/dev/null || echo missing)"
 fi
 
-REVIEW_PROMPT="$REPO_REVIEW/.humanize/rlcr/2026-03-14_12-00-00/round-2-review-prompt.md"
+REVIEW_PROMPT=""
+if [[ -d "$REPO_REVIEW/.humanize/rlcr" ]]; then
+    REVIEW_PROMPT=$(find "$REPO_REVIEW/.humanize/rlcr" -mindepth 2 -maxdepth 2 -type f -name 'round-*-review-prompt.md' -print | sort | tail -n 1)
+fi
 if [[ -f "$REVIEW_PROMPT" ]] && grep -q -- 'must not pass prompt input when `--base` is used' "$REVIEW_PROMPT"; then
     pass "review audit prompt documents --base prompt incompatibility"
 else

--- a/tests/test-disable-nested-codex-hooks.sh
+++ b/tests/test-disable-nested-codex-hooks.sh
@@ -99,6 +99,24 @@ if [[ "\$subcommand" == "exec" ]]; then
 fi
 
 if [[ "\$subcommand" == "review" ]]; then
+    saw_base=false
+    saw_prompt=false
+    for arg in "\$@"; do
+        if [[ "\$arg" == "--base" ]]; then
+            saw_base=true
+        elif [[ "\$arg" == "-" ]]; then
+            saw_prompt=true
+        fi
+    done
+    if [[ "\$saw_base" == "true" && "\$saw_prompt" == "true" ]]; then
+        echo "codex 0.130.0 rejects --base with prompt input" >&2
+        exit 64
+    fi
+    if IFS= read -r stdin_line; then
+        printf 'STDIN:%s\n' "\$stdin_line" >> "$args_file"
+        echo "codex review must not receive stdin when --base is used" >&2
+        exit 65
+    fi
     echo "No issues found."
     exit 0
 fi
@@ -204,6 +222,21 @@ if grep -q -- 'review --disable hooks' "$TEST_DIR/review.args"; then
 else
     fail "review-phase stop hook disables hooks for codex review" \
         "review --disable hooks" "$(cat "$TEST_DIR/review.args" 2>/dev/null || echo missing)"
+fi
+
+if grep -q -- ' --base ' "$TEST_DIR/review.args" && ! grep -q -- ' -$' "$TEST_DIR/review.args" && ! grep -q '^STDIN:' "$TEST_DIR/review.args"; then
+    pass "review-phase codex review uses --base without prompt input"
+else
+    fail "review-phase codex review avoids --base plus prompt input" \
+        "--base arguments with no trailing '-' and no stdin" "$(cat "$TEST_DIR/review.args" 2>/dev/null || echo missing)"
+fi
+
+REVIEW_PROMPT="$REPO_REVIEW/.humanize/rlcr/2026-03-14_12-00-00/round-2-review-prompt.md"
+if [[ -f "$REVIEW_PROMPT" ]] && grep -q -- 'must not pass prompt input when `--base` is used' "$REVIEW_PROMPT"; then
+    pass "review audit prompt documents --base prompt incompatibility"
+else
+    fail "review audit prompt documents --base prompt incompatibility" \
+        'must not pass prompt input when `--base` is used' "$(cat "$REVIEW_PROMPT" 2>/dev/null || echo missing)"
 fi
 
 echo ""

--- a/tests/test-finalize-phase.sh
+++ b/tests/test-finalize-phase.sh
@@ -732,7 +732,8 @@ echo "T-NEG-9b: Codex review log file exists and is empty"
 # Compute the real cache dir using same logic as loop-codex-stop-hook.sh
 # Cache path: $XDG_CACHE_HOME/humanize/$SANITIZED_PROJECT_PATH/$LOOP_TIMESTAMP/round-N-codex-review.log
 LOOP_TIMESTAMP=$(basename "$LOOP_DIR")
-SANITIZED_PROJECT_PATH=$(echo "$TEST_DIR" | sed 's/[^a-zA-Z0-9._-]/-/g' | sed 's/--*/-/g')
+CANONICAL_TEST_DIR="$(cd "$TEST_DIR" && pwd -P)"
+SANITIZED_PROJECT_PATH=$(echo "$CANONICAL_TEST_DIR" | sed 's/[^a-zA-Z0-9._-]/-/g' | sed 's/--*/-/g')
 REVIEW_CACHE_DIR="$XDG_CACHE_HOME/humanize/$SANITIZED_PROJECT_PATH/$LOOP_TIMESTAMP"
 # Round 5 because we pass CURRENT_ROUND + 1 (4 + 1 = 5) to run_and_handle_code_review
 REVIEW_LOG="$REVIEW_CACHE_DIR/round-5-codex-review.log"


### PR DESCRIPTION
## Summary
- add regression coverage that rejects `codex review --base ... -` and stdin prompt input
- update the review audit prompt to document the Codex 0.130.0 `--base` + `[PROMPT]` incompatibility
- guard empty Bash arrays in nested Codex/template paths and align finalize cache-path test with canonical project roots

## Verification
- `git diff --check HEAD~1..HEAD`
- `bash tests/test-disable-nested-codex-hooks.sh`
- `bash tests/test-templates-comprehensive.sh`
- `bash tests/test-finalize-phase.sh`

Note: `bash tests/run-all-tests.sh` is not a valid aggregate verification on this macOS host because the runner uses Bash 4 associative arrays while /bin/bash is 3.2.57.