### PR TITLE
fix(humanize2): pass agentDefaults to AgentRunCoordinator and support per-agent permission/sandbox/extraArgs

### DIFF
--- a/src/config.ts
+++ b/src/config.ts
@@ -252,6 +252,7 @@ function parseSimpleYaml(
     }
     if ((section === "agents" || section === "agents.extraArgs") && indent === 2) {
       currentAgent = key === "codex" || key === "claude" ? key : undefined;
+      section = "agents";
       continue;
     }
     if (section === "agents" && indent >= 4 && currentAgent !== undefined && value.length > 0) {

--- a/src/config.ts
+++ b/src/config.ts
@@ -158,7 +158,7 @@ function parseSimpleYaml(
   const values: Partial<Pick<HumanizeConfig, "cacheDir" | "defaultRunTimeoutMs" | "defaultTheme" | "agentDefaults" | "workflow">> = {
     agentDefaults: {}
   };
-  let section: "agents" | "workflow" | "workflow.softEnforcement" | "workflow.scripts" | "workflow.scripts.allow" | undefined;
+  let section: "agents" | "workflow" | "workflow.softEnforcement" | "workflow.scripts" | "workflow.scripts.allow" | "agents.extraArgs" | undefined;
   let currentAgent: AgentId | undefined;
 
   for (const line of contents.split("\n")) {
@@ -180,7 +180,7 @@ function parseSimpleYaml(
     }
 
     // agent extraArgs list items (e.g., `  - --skip-git-repo-check`)
-    if (section === "agents" && indent >= 6 && currentAgent !== undefined && trimmed.startsWith("- ")) {
+    if (section === "agents.extraArgs" && indent >= 6 && currentAgent !== undefined && trimmed.startsWith("- ")) {
       const item = trimmed.slice(2).trim().replace(/^["']|["']$/g, "");
       if (item.length > 0) {
         const defaults = values.agentDefaults?.[currentAgent] ?? {};
@@ -250,7 +250,7 @@ function parseSimpleYaml(
       section = "workflow.scripts.allow";
       continue;
     }
-    if (section === "agents" && indent === 2) {
+    if ((section === "agents" || section === "agents.extraArgs") && indent === 2) {
       currentAgent = key === "codex" || key === "claude" ? key : undefined;
       continue;
     }
@@ -277,6 +277,7 @@ function parseSimpleYaml(
       const defaults = values.agentDefaults?.[currentAgent] ?? {};
       if (value === "[]" || value.length === 0) {
         defaults.extraArgs = [];
+        section = "agents.extraArgs";
       } else {
         defaults.extraArgs = parseCommaList(value);
       }

--- a/src/config.ts
+++ b/src/config.ts
@@ -2,7 +2,7 @@ import { existsSync, mkdirSync, readFileSync, writeFileSync } from "node:fs";
 import { homedir } from "node:os";
 import { dirname, join } from "node:path";
 
-import type { AgentId } from "./agents/types.js";
+import type { AgentId, PermissionMode, SandboxMode } from "./agents/types.js";
 
 export const DEFAULT_RUN_TIMEOUT_MS = 6 * 60 * 60 * 1000;
 export const DEFAULT_DASHBOARD_THEME: DashboardTheme = "dark";
@@ -12,6 +12,9 @@ export type DashboardTheme = "light" | "dark";
 export interface AgentModelDefaults {
   model?: string;
   reasoningEffort?: string;
+  permissionMode?: PermissionMode;
+  sandbox?: SandboxMode;
+  extraArgs?: string[];
 }
 
 export type AgentModelDefaultsByAgent = Partial<Record<AgentId, AgentModelDefaults>>;
@@ -176,6 +179,20 @@ function parseSimpleYaml(
       continue;
     }
 
+    // agent extraArgs list items (e.g., `  - --skip-git-repo-check`)
+    if (section === "agents" && indent >= 6 && currentAgent !== undefined && trimmed.startsWith("- ")) {
+      const item = trimmed.slice(2).trim().replace(/^["']|["']$/g, "");
+      if (item.length > 0) {
+        const defaults = values.agentDefaults?.[currentAgent] ?? {};
+        defaults.extraArgs = [...(defaults.extraArgs ?? []), item];
+        values.agentDefaults = {
+          ...values.agentDefaults,
+          [currentAgent]: defaults
+        };
+      }
+      continue;
+    }
+
     const separatorIndex = trimmed.indexOf(":");
     if (separatorIndex < 0) {
       continue;
@@ -245,6 +262,24 @@ function parseSimpleYaml(
       if (key === "reasoningEffort") {
         defaults.reasoningEffort = value;
       }
+      if (key === "permissionMode") {
+        defaults.permissionMode = value as PermissionMode;
+      }
+      if (key === "sandbox") {
+        defaults.sandbox = value as SandboxMode;
+      }
+      values.agentDefaults = {
+        ...values.agentDefaults,
+        [currentAgent]: defaults
+      };
+    }
+    if (section === "agents" && indent >= 4 && currentAgent !== undefined && key === "extraArgs") {
+      const defaults = values.agentDefaults?.[currentAgent] ?? {};
+      if (value === "[]" || value.length === 0) {
+        defaults.extraArgs = [];
+      } else {
+        defaults.extraArgs = parseCommaList(value);
+      }
       values.agentDefaults = {
         ...values.agentDefaults,
         [currentAgent]: defaults
@@ -262,11 +297,13 @@ function mergeAgentDefaults(
   return {
     codex: {
       ...defaults.codex,
-      ...overrides?.codex
+      ...overrides?.codex,
+      extraArgs: overrides?.codex?.extraArgs ?? defaults.codex?.extraArgs
     },
     claude: {
       ...defaults.claude,
-      ...overrides?.claude
+      ...overrides?.claude,
+      extraArgs: overrides?.claude?.extraArgs ?? defaults.claude?.extraArgs
     }
   };
 }

--- a/src/config.ts
+++ b/src/config.ts
@@ -193,6 +193,12 @@ function parseSimpleYaml(
       continue;
     }
 
+    // extraArgs list is done — reset section so sibling fields (model,
+    // permissionMode, sandbox) under the same agent are not silently ignored
+    if (section === "agents.extraArgs" && indent >= 4 && currentAgent !== undefined && !trimmed.startsWith("- ")) {
+      section = "agents";
+    }
+
     const separatorIndex = trimmed.indexOf(":");
     if (separatorIndex < 0) {
       continue;

--- a/src/hub-server.ts
+++ b/src/hub-server.ts
@@ -30,7 +30,8 @@ async function main(): Promise<void> {
     jsonRpcUrl,
     store,
     initialRuns,
-    defaultRunTimeoutMs: config.defaultRunTimeoutMs
+    defaultRunTimeoutMs: config.defaultRunTimeoutMs,
+    agentDefaults: config.agentDefaults
   });
   const workflowCoordinator = new WorkflowCoordinator(coordinator, {
     store: workflowStore,

--- a/src/hub/runs.ts
+++ b/src/hub/runs.ts
@@ -147,6 +147,9 @@ export class AgentRunCoordinator {
       ...input,
       model: input.model ?? defaults.model,
       reasoningEffort: input.reasoningEffort ?? defaults.reasoningEffort,
+      permissionMode: input.permissionMode ?? defaults.permissionMode,
+      sandbox: input.sandbox ?? defaults.sandbox,
+      extraArgs: input.extraArgs ?? defaults.extraArgs,
       cwd: input.cwd ?? parentRun?.cwd,
       workflowContext: input.workflowContext ?? inheritedWorkflowContext
     };

--- a/tests/config.test.ts
+++ b/tests/config.test.ts
@@ -93,6 +93,42 @@ describe("humanize2 user config", () => {
     expect(config.defaultTheme).toBe("light");
   });
 
+  it("loads agent model fields after a prior agent's multiline extraArgs list", async () => {
+    const home = await tempDirectory();
+    const configPath = join(home, "multiline-extraargs-config.yaml");
+
+    const contents = [
+      "version: 1",
+      "cacheDir: /tmp/humanize2-cache",
+      "defaultRunTimeoutMs: 12345",
+      "defaultTheme: dark",
+      "agents:",
+      "  codex:",
+      "    model: gpt-5.4",
+      "    extraArgs:",
+      "      - --temperature",
+      "      - 0.7",
+      "      - --max-tokens",
+      "      - 4096",
+      "  claude:",
+      "    model: claude-opus-4-7",
+      "    reasoningEffort: xhigh",
+      ""
+    ].join("\n");
+    await writeFile(configPath, contents, "utf8");
+
+    const config = await loadHumanizeConfig({ HUMANIZE2_CONFIG: configPath }, home);
+
+    expect(config.agentDefaults.codex).toMatchObject({
+      model: "gpt-5.4",
+      extraArgs: ["--temperature", "0.7", "--max-tokens", "4096"]
+    });
+    expect(config.agentDefaults.claude).toMatchObject({
+      model: "claude-opus-4-7",
+      reasoningEffort: "xhigh"
+    });
+  });
+
   it("loads workflow retry and script allowlist settings from the user config", async () => {
     const home = await tempDirectory();
     const configPath = join(home, "workflow-config.yaml");

--- a/tests/config.test.ts
+++ b/tests/config.test.ts
@@ -129,6 +129,33 @@ describe("humanize2 user config", () => {
     });
   });
 
+  it("loads sibling fields after empty extraArgs under the same agent", async () => {
+    const home = await tempDirectory();
+    const configPath = join(home, "sibling-after-extraargs-config.yaml");
+
+    const contents = [
+      "version: 1",
+      "cacheDir: /tmp/humanize2-cache",
+      "defaultRunTimeoutMs: 12345",
+      "defaultTheme: dark",
+      "agents:",
+      "  codex:",
+      "    extraArgs: []",
+      "    model: gpt-5.5",
+      "    reasoningEffort: xhigh",
+      ""
+    ].join("\n");
+    await writeFile(configPath, contents, "utf8");
+
+    const config = await loadHumanizeConfig({ HUMANIZE2_CONFIG: configPath }, home);
+
+    expect(config.agentDefaults.codex).toMatchObject({
+      model: "gpt-5.5",
+      reasoningEffort: "xhigh",
+      extraArgs: []
+    });
+  });
+
   it("loads workflow retry and script allowlist settings from the user config", async () => {
     const home = await tempDirectory();
     const configPath = join(home, "workflow-config.yaml");


### PR DESCRIPTION
## Summary

Two fixes for humanize2 workflow agent launches that were blocking `gen-idea` and other workflows from completing successfully.

### Bug 1: `agentDefaults` not passed to `AgentRunCoordinator`

**Root cause**: `AgentRunCoordinator` was constructed without `agentDefaults` in `hub-server.ts`. The config was loaded and passed to `createHubHttpServer`, but the `AgentRunCoordinator` (which actually creates and executes agent runs) never received it. This meant `permissionMode`, `sandbox`, and `extraArgs` from `~/.h2/config.yaml` were silently ignored.

**Impact**: 
- Claude agents ran with `permissionMode: default`, blocking MCP tool calls (`artifact_deliver`, `artifact_get`) that require user approval in headless `claude -p` mode
- Codex agents failed with "Not inside a trusted directory" when the working directory is not a git repo

### Feature: Extended agent config surface

`AgentModelDefaults` now supports three new per-agent fields:

| Field | Type | Purpose |
|-------|------|---------|
| `permissionMode` | `PermissionMode` | Claude CLI `--permission-mode` (e.g., `bypassPermissions`) |
| `sandbox` | `SandboxMode` | Codex CLI `--sandbox` |
| `extraArgs` | `string[]` | Arbitrary extra CLI args (e.g., `--skip-git-repo-check`, `--dangerously-bypass-approvals-and-sandbox`) |

YAML parser supports both inline comma-separated values and multi-line list items for `extraArgs`.

### Configuration example

```yaml
agents:
  claude:
    model: claude-opus-4-7
    reasoningEffort: xhigh
    permissionMode: bypassPermissions
  codex:
    model: gpt-5.5
    reasoningEffort: xhigh
    extraArgs:
      - --dangerously-bypass-approvals-and-sandbox
      - --skip-git-repo-check
```

## Changes

| File | Change |
|------|--------|
| `src/config.ts` | Extended `AgentModelDefaults` interface + YAML parser |
| `src/hub/runs.ts` | Applied `permissionMode`/`sandbox`/`extraArgs` from config defaults in `createRun` |
| `src/hub-server.ts` | Passed `agentDefaults` to `AgentRunCoordinator` constructor (critical bugfix) |

## Verification

Tested with `gen-idea` workflow:
- Before: 3/3 Codex explorers failed, Claude explorers needed per-tool permission allowlisting
- After: All 6 explorers completed successfully, `idea-draft` delivered correctly

Closes #165