### PR TITLE
Fix typo in README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -30,11 +30,11 @@ The loop has two phases: **Implementation** (Claude works, Codex reviews summari
 
 ```bash
 # Add PolyArch marketplace
-/plugin marketplace add PolyArch/humanize
+/plugins marketplace add PolyArch/humanize
 # If you want to use development branch for experimental features
-/plugin marketplace add PolyArch/humanize#dev
+/plugins marketplace add PolyArch/humanize#dev
 # Then install humanize plugin
-/plugin install humanize@PolyArch
+/plugins install humanize@PolyArch
 ```
 
 Requires [codex CLI](https://github.com/openai/codex) for review. See the full [Installation Guide](docs/install-for-claude.md) for prerequisites and alternative setup options.


### PR DESCRIPTION
Unrecognized command '/plugin' in codex-cli 0.130.0. It should be /plugins, which is also supported in claude code