### PR TITLE
Add alternative language variants for idea artifacts

### DIFF
--- a/commands/explore-idea.md
+++ b/commands/explore-idea.md
@@ -1,6 +1,6 @@
 ---
 description: "Launch bounded parallel prototype workers for idea directions and synthesize canonical explore artifacts"
-argument-hint: "<draft-or-directions-json> [--directions ids] [--concurrency N] [--max-worker-iterations N] [--worker-timeout-min N] [--codex-timeout-min N]"
+argument-hint: "<draft-or-directions-json> [--directions ids] [--concurrency N] [--max-worker-iterations N] [--worker-timeout-min N] [--codex-timeout-min N] [--alt-language <language-or-code>]"
 allowed-tools:
   - "Bash(${CLAUDE_PLUGIN_ROOT}/scripts/validate-explore-idea-io.sh:*)"
   - "Bash(${CLAUDE_PLUGIN_ROOT}/scripts/validate-directions-json.sh:*)"
@@ -25,7 +25,8 @@ Read and execute below with ultrathink.
 - MUST NOT run workers until the user explicitly confirms the dispatch.
 - MUST NOT push any branch to any remote at any point.
 - MUST write `manifest.json` to the run directory BEFORE dispatching any worker.
-- MUST write canonical artifacts to `explore-report.md` and `final-idea.md`; do not create any legacy compatibility alias.
+- MUST write canonical artifacts to `explore-report.md` and `final-idea.md`; may additionally write only the optional translated `final-idea` variant; do not create any legacy compatibility alias.
+- MUST NOT translate or create variants for `explore-report.md`, `manifest.json`, `worker-results.jsonl`, or `dispatch-prompts/`.
 - MUST NOT invoke nested Skills or slash commands inside worker prompts.
 - MUST NOT use `--effort max` (not supported by `ask-codex.sh`).
 - Worker branches follow the format `explore/<RUN_ID>/<dir_slug>` exactly, and MUST be created by running `git checkout -b` from the current HEAD after asserting `HEAD == <BASE_COMMIT>`; workers MUST NOT run `git checkout <BASE_BRANCH>` (that branch is already checked out in the coordinator worktree, and Git forbids two worktrees from checking out the same branch simultaneously); a HEAD mismatch is a fatal worker error.
@@ -41,6 +42,7 @@ The per-direction worker constraints are defined in `WORKER_PROMPT_TEMPLATE` (fr
 ## Workflow
 
 1. IO Validation
+1.5. Load Project Config
 2. Confirmation
 3. Run State Initialization
 4. Worker Dispatch (parallel)
@@ -51,9 +53,13 @@ The per-direction worker constraints are defined in `WORKER_PROMPT_TEMPLATE` (fr
 
 ## Phase 1: IO Validation
 
+Before running validation, parse `$ARGUMENTS` and set `CLI_ALT_LANGUAGE_RAW` from `--alt-language`, or empty string when omitted. If `--alt-language` is present without a value, report `Invalid arguments: --alt-language requires a value` and stop.
+
+Build `VALIDATOR_ARGUMENTS` from `$ARGUMENTS` by removing `--alt-language` and its value. Keep `--alt-language` out of the validator invocation because `validate-explore-idea-io.sh` does not accept it.
+
 Run:
 ```bash
-"${CLAUDE_PLUGIN_ROOT}/scripts/validate-explore-idea-io.sh" $ARGUMENTS
+"${CLAUDE_PLUGIN_ROOT}/scripts/validate-explore-idea-io.sh" $VALIDATOR_ARGUMENTS
 ```
 
 Handle exit codes:
@@ -63,7 +69,7 @@ Handle exit codes:
   `REPORT_PATH`, `FINAL_IDEA_PATH`, `FINAL_IDEA_TEMPLATE`,
   `SELECTED_DIRECTION_IDS`, `EFFECTIVE_CONCURRENCY`, `MAX_WORKER_ITERATIONS`,
   `WORKER_TIMEOUT_MIN`, `CODEX_TIMEOUT_MIN`, `WORKER_PROMPT_TEMPLATE`, `REPORT_TEMPLATE`.
-  Continue to Phase 2.
+  Continue to Phase 1.5.
   Parse values by splitting each line on the first literal `": "` only. Values can contain additional colons, for example `CODEX_REVIEW_MODEL_SPEC: gpt-5.5:xhigh`.
 - `1`: Report "No input path provided" and stop.
 - `2`: Report "Input file not found" and stop.
@@ -78,6 +84,67 @@ Handle exit codes:
 Load the directions JSON:
 - Read `DIRECTIONS_JSON_FILE` to get the full directions data for later use.
 - `SELECTED_DIRECTION_IDS` is a space-separated list of `direction_id` values that were selected.
+
+---
+
+## Phase 1.5: Load Project Config
+
+Resolve configuration by following the same precedence and merge semantics defined in `${CLAUDE_PLUGIN_ROOT}/scripts/lib/config-loader.sh`. Reuse that behavior; do not invent a separate explore-idea config model.
+
+### Config Merge Semantics
+
+Use the same layer order as `load_merged_config`:
+
+1. Required default config: `${CLAUDE_PLUGIN_ROOT}/config/default_config.json`
+2. Optional user config: `${XDG_CONFIG_HOME:-$HOME/.config}/humanize/config.json`
+3. Optional project config: `${HUMANIZE_CONFIG:-$PROJECT_ROOT/.humanize/config.json}`
+
+Later layers override earlier layers. Malformed optional JSON objects are treated as warnings and ignored. A malformed required default config is a fatal configuration error.
+
+### Values to Extract
+
+Read the merged config and resolve:
+
+- `CONFIG_ALT_LANGUAGE_RAW` from `alternative_plan_language`
+
+### Alternative Language Resolution
+
+Resolve the variant language with this priority:
+
+1. CLI `--alt-language`
+2. Config `alternative_plan_language`
+3. No variant
+
+Normalize the value case-insensitively using this mapping table:
+
+| Language   | Code | Suffix |
+|------------|------|--------|
+| Chinese    | zh   | `_zh`  |
+| Korean     | ko   | `_ko`  |
+| Japanese   | ja   | `_ja`  |
+| Spanish    | es   | `_es`  |
+| French     | fr   | `_fr`  |
+| German     | de   | `_de`  |
+| Portuguese | pt   | `_pt`  |
+| Russian    | ru   | `_ru`  |
+| Arabic     | ar   | `_ar`  |
+
+Normalization rules:
+
+1. Trim leading and trailing whitespace before matching.
+2. Accept either the full language name or the ISO code from the table.
+3. Treat `English` / `en` as a no-op: no translated variant is generated.
+4. If the CLI value is unsupported, report `Unsupported --alt-language "<value>"` and stop.
+5. If the config value is unsupported, log a warning and disable variant generation.
+
+Set:
+
+- `ALT_PLAN_LANGUAGE` to the normalized language name or empty string
+- `ALT_PLAN_LANG_CODE` to the normalized code or empty string
+
+Do not depend on deprecated `chinese_plan`. `explore-idea` only uses `alternative_plan_language`.
+
+If `ALT_PLAN_LANGUAGE` is non-empty, compute `FINAL_IDEA_VARIANT_PATH` by inserting `_<ALT_PLAN_LANG_CODE>` before the extension of `FINAL_IDEA_PATH`, or appending it when there is no extension. If `ALT_PLAN_LANGUAGE` is empty, set `FINAL_IDEA_VARIANT_PATH` to empty.
 
 ---
 
@@ -97,6 +164,7 @@ Base branch:     <BASE_BRANCH>
 Base commit:     <BASE_COMMIT>
 Explore report:  <REPORT_PATH>
 Final idea:      <FINAL_IDEA_PATH>
+Final idea variant: <FINAL_IDEA_VARIANT_PATH or "(disabled)">
 
 Selected directions (<N> of <total>):
   [1] <direction_id>: <name>
@@ -267,8 +335,15 @@ After collecting all results, update the `workers` array in `manifest.json` to s
 Generate the canonical run artifacts:
 - `<REPORT_PATH>` (`explore-report.md`) by reading `REPORT_TEMPLATE` and synthesizing results.
 - `<FINAL_IDEA_PATH>` (`final-idea.md`) by reading `FINAL_IDEA_TEMPLATE` and producing a plan-ready synthesis for `/humanize:gen-plan`.
+- `<FINAL_IDEA_VARIANT_PATH>` (`final-idea_<code>.md`) only when `ALT_PLAN_LANGUAGE` is enabled; write it after `<FINAL_IDEA_PATH>` is complete.
 
 Do not create any legacy compatibility alias for the report.
+
+Artifacts that must not be translated:
+- `explore-report.md` is not translated.
+- `manifest.json` is not translated.
+- `worker-results.jsonl` is not translated.
+- `dispatch-prompts/` is not translated.
 
 ### 6.1: Load Results
 
@@ -373,6 +448,31 @@ If all workers failed (`.failed` exists), still write `<REPORT_PATH>` with:
 - No ranking sections
 
 Also write `<FINAL_IDEA_PATH>` with a clear "no adoption recommended" final recommendation and the evidence needed before retrying or planning.
+
+### 6.7: Translated Final Idea Variant (Conditional)
+
+After writing `<FINAL_IDEA_PATH>` for either the success path or all-workers-failed path, if `ALT_PLAN_LANGUAGE` is non-empty, write `<FINAL_IDEA_VARIANT_PATH>`.
+
+Filename construction rule for variants:
+
+1. If the filename has an extension, insert `_<ALT_PLAN_LANG_CODE>` before the last `.`.
+2. If the filename has no extension, append `_<ALT_PLAN_LANG_CODE>`.
+3. The variant file is placed in the same directory as `FINAL_IDEA_PATH`.
+
+Examples:
+
+- `final-idea.md -> final-idea_zh.md`
+- `.humanize/explore/<RUN_ID>/final-idea.md -> .humanize/explore/<RUN_ID>/final-idea_zh.md`
+
+Variant content rules:
+
+1. Translate human-readable final idea prose into `ALT_PLAN_LANGUAGE`; for Chinese, default to Simplified Chinese.
+2. Preserve paths, branch names, commit SHAs, direction IDs, API names, command flags, and shell commands.
+3. Keep the productization command pointing at canonical `FINAL_IDEA_PATH`: `/humanize:gen-plan --input <FINAL_IDEA_PATH> --output <plan-path>`.
+4. Do not add information that is absent from the canonical final idea.
+5. Apply the same rules to success final ideas and all-workers-failed final idea outputs.
+
+Do not create translated variants for `explore-report.md`, `manifest.json`, `worker-results.jsonl`, or `dispatch-prompts/`.
 
 ---
 

--- a/commands/gen-idea.md
+++ b/commands/gen-idea.md
@@ -1,6 +1,6 @@
 ---
 description: "Generate a repo-grounded idea draft via directed-swarm exploration"
-argument-hint: "<idea-text-or-path> [--n <int>] [--output <path>]"
+argument-hint: "<idea-text-or-path> [--n <int>] [--output <path>] [--alt-language <language-or-code>]"
 allowed-tools:
   - "Bash(${CLAUDE_PLUGIN_ROOT}/scripts/validate-gen-idea-io.sh:*)"
   - "Bash(${CLAUDE_PLUGIN_ROOT}/scripts/validate-directions-json.sh:*)"
@@ -18,7 +18,7 @@ Read and execute below with ultrathink.
 
 ## Hard Constraint: Draft-Only Output
 
-This command MUST NOT implement features, modify source code, or create commits while producing the draft. Permitted writes are limited to the output draft file and its companion `directions.json` artifact produced in Phase 4; prerequisite directory creation for the default `.humanize/ideas/` path by the validation script is permitted. `rm` is permitted solely to delete those two just-written files when companion JSON validation fails (no-partial-output cleanup). All exploration subagents run read-only.
+This command MUST NOT implement features, modify source code, or create commits while producing the draft. Permitted writes are limited to the output draft file, its companion `directions.json` artifact produced in Phase 4, and the optional translated draft variant; prerequisite directory creation for the default `.humanize/ideas/` path by the validation script is permitted. `rm` is permitted solely to delete the two just-written canonical files when companion JSON validation fails (no-partial-output cleanup). All exploration subagents run read-only.
 
 This command transforms a loose idea into a repo-grounded draft suitable as input to `/humanize:gen-plan`. It applies directed-diversity exploration: a lead picks N orthogonal directions, N parallel `Explore` subagents develop each, the lead synthesizes a draft with one primary direction plus N-1 alternatives. Each direction carries objective evidence from the repo.
 
@@ -28,9 +28,10 @@ This command transforms a loose idea into a repo-grounded draft suitable as inpu
 
 1. Parse Input
 2. IO Validation
-3. Direction Generation
-4. Parallel Exploration
-5. Synthesis, Write Draft, and Write Companion JSON
+3. Load Project Config
+4. Direction Generation
+5. Parallel Exploration
+6. Synthesis, Write Draft, and Write Companion JSON
 
 ---
 
@@ -40,8 +41,11 @@ Extract from `$ARGUMENTS`:
 - First positional: inline idea text or path to a `.md` file (required).
 - `--n <int>`: number of directions. Default 6.
 - `--output <path>`: target draft path. Default resolved by the validation script.
+- `--alt-language <language-or-code>`: optional translated draft variant language.
 
-Do not interpret or rewrite the idea text here. Pass `$ARGUMENTS` through to Phase 1 unchanged.
+Set `CLI_ALT_LANGUAGE_RAW` from `--alt-language`, or empty string when omitted. If `--alt-language` is present without a value, report `Invalid arguments: --alt-language requires a value` and stop.
+
+Build `VALIDATOR_ARGUMENTS` from `$ARGUMENTS` by removing `--alt-language` and its value. Keep `--alt-language` out of the validator invocation because `validate-gen-idea-io.sh` does not accept it. Do not otherwise interpret or rewrite the idea text before Phase 1.
 
 ---
 
@@ -49,11 +53,11 @@ Do not interpret or rewrite the idea text here. Pass `$ARGUMENTS` through to Pha
 
 Run:
 ```bash
-"${CLAUDE_PLUGIN_ROOT}/scripts/validate-gen-idea-io.sh" $ARGUMENTS
+"${CLAUDE_PLUGIN_ROOT}/scripts/validate-gen-idea-io.sh" $VALIDATOR_ARGUMENTS
 ```
 
 Handle exit codes:
-- `0`: Parse stdout to extract `INPUT_MODE`, `OUTPUT_FILE`, `DIRECTIONS_JSON_FILE`, `SLUG`, `TEMPLATE_FILE`, `N` (each appears on its own `KEY: value` line). When `INPUT_MODE` is `file`, stdout additionally contains an `IDEA_BODY_FILE: <path>` line; extract that too. Continue to Phase 2. (`SLUG` is informational — the script has already incorporated it into `OUTPUT_FILE`, so later phases do not need to use `SLUG` directly.)
+- `0`: Parse stdout to extract `INPUT_MODE`, `OUTPUT_FILE`, `DIRECTIONS_JSON_FILE`, `SLUG`, `TEMPLATE_FILE`, `N` (each appears on its own `KEY: value` line). When `INPUT_MODE` is `file`, stdout additionally contains an `IDEA_BODY_FILE: <path>` line; extract that too. Continue to Phase 1.5. (`SLUG` is informational — the script has already incorporated it into `OUTPUT_FILE`, so later phases do not need to use `SLUG` directly.)
 - `1`: Report "Missing or empty idea input" and stop.
 - `2`: Report "Input looks like a file path but is missing, not readable, or not `.md`" and stop.
 - `3`: Report "Output directory does not exist — please create it or choose a different path" and stop.
@@ -63,13 +67,80 @@ Handle exit codes:
 - `7`: Report "Template file missing — plugin configuration error" and stop.
 - `8`: Report "Companion directions.json already exists — choose a different output path or remove the existing companion file" and stop.
 
-Before `VALIDATION_SUCCESS`, stdout may contain one or more lines starting with `WARNING:` (for example, `WARNING: short idea (<N> chars); proceeding` when an inline idea is under 10 characters). Surface these warnings to the user in your final report but continue Phase 2 normally. `WARNING:` lines are informational, not errors.
+Before `VALIDATION_SUCCESS`, stdout may contain one or more lines starting with `WARNING:` (for example, `WARNING: short idea (<N> chars); proceeding` when an inline idea is under 10 characters). Surface these warnings to the user in your final report but continue Phase 1.5 normally. `WARNING:` lines are informational, not errors.
 
 Obtain the idea body into memory as `IDEA_BODY`, based on `INPUT_MODE`:
 - `inline`: stdout contains a sentinel block at the end of the success output; extract all text between the `=== IDEA_BODY_BEGIN ===` and `=== IDEA_BODY_END ===` lines (exclusive). The script emits a trailing newline after the last body line.
 - `file`: read the full contents of `IDEA_BODY_FILE` using the `Read` tool.
 
 Preserve byte-identical content in memory for later phases. No on-disk tempfile is created in inline mode — the stdout sentinel block is the authoritative source.
+
+---
+
+## Phase 1.5: Load Project Config
+
+Resolve configuration by following the same precedence and merge semantics defined in `${CLAUDE_PLUGIN_ROOT}/scripts/lib/config-loader.sh`. Reuse that behavior; do not invent a separate gen-idea config model.
+
+### Config Merge Semantics
+
+Use the same layer order as `load_merged_config`:
+
+1. Required default config: `${CLAUDE_PLUGIN_ROOT}/config/default_config.json`
+2. Optional user config: `${XDG_CONFIG_HOME:-$HOME/.config}/humanize/config.json`
+3. Optional project config: `${HUMANIZE_CONFIG:-$PROJECT_ROOT/.humanize/config.json}`
+
+Later layers override earlier layers. Malformed optional JSON objects are treated as warnings and ignored. A malformed required default config is a fatal configuration error.
+
+### Values to Extract
+
+Read the merged config and resolve:
+
+- `CONFIG_ALT_LANGUAGE_RAW` from `alternative_plan_language`
+
+### Alternative Language Resolution
+
+Resolve the variant language with this priority:
+
+1. CLI `--alt-language`
+2. Config `alternative_plan_language`
+3. No variant
+
+Normalize the value case-insensitively using this mapping table:
+
+| Language   | Code | Suffix |
+|------------|------|--------|
+| Chinese    | zh   | `_zh`  |
+| Korean     | ko   | `_ko`  |
+| Japanese   | ja   | `_ja`  |
+| Spanish    | es   | `_es`  |
+| French     | fr   | `_fr`  |
+| German     | de   | `_de`  |
+| Portuguese | pt   | `_pt`  |
+| Russian    | ru   | `_ru`  |
+| Arabic     | ar   | `_ar`  |
+
+Normalization rules:
+
+1. Trim leading and trailing whitespace before matching.
+2. Accept either the full language name or the ISO code from the table.
+3. Treat `English` / `en` as a no-op: no translated variant is generated.
+4. If the CLI value is unsupported, report `Unsupported --alt-language "<value>"` and stop.
+5. If the config value is unsupported, log a warning and disable variant generation.
+
+Set:
+
+- `ALT_PLAN_LANGUAGE` to the normalized language name or empty string
+- `ALT_PLAN_LANG_CODE` to the normalized code or empty string
+
+Do not depend on deprecated `chinese_plan`. `gen-idea` only uses `alternative_plan_language`.
+
+`ALT_PLAN_LANGUAGE` and `ALT_PLAN_LANG_CODE` control whether a translated draft variant is written after the companion JSON validates successfully.
+
+If `ALT_PLAN_LANGUAGE` is non-empty, compute `DRAFT_VARIANT_FILE` from `OUTPUT_FILE` by inserting `_<ALT_PLAN_LANG_CODE>` before the `.md` suffix. `validate-gen-idea-io.sh` guarantees `OUTPUT_FILE` has a `.md` suffix, so there is no extensionless variant case for `gen-idea`.
+
+Before Phase 2, check whether `DRAFT_VARIANT_FILE` already exists. If it exists, stop before any canonical outputs are written with: `Translated draft variant already exists — choose a different output path or remove the existing variant file`.
+
+If `ALT_PLAN_LANGUAGE` is empty, set `DRAFT_VARIANT_FILE` to empty and skip the variant collision check.
 
 ---
 
@@ -246,13 +317,39 @@ After writing `DIRECTIONS_JSON_FILE`, validate it:
 "${CLAUDE_PLUGIN_ROOT}/scripts/validate-directions-json.sh" "$DIRECTIONS_JSON_FILE"
 ```
 
-If validation fails, delete both `OUTPUT_FILE` and `DIRECTIONS_JSON_FILE` and stop with error: `companion JSON validation failed — this is a bug in the command; please report it`.
+If validation fails, delete both `OUTPUT_FILE` and `DIRECTIONS_JSON_FILE` and stop with error: `companion JSON validation failed — this is a bug in the command; please report it`. The translated draft variant MUST NOT have been written yet.
 
-### Step 4.6: Report
+### Step 4.6: Write Translated Draft Variant (Conditional)
+
+If `ALT_PLAN_LANGUAGE` is non-empty, write the translated draft variant to `DRAFT_VARIANT_FILE` after companion JSON validation passes. `DRAFT_VARIANT_FILE` was computed and checked for collision in Phase 1.5 before any canonical outputs were written.
+
+Filename construction rule for variants:
+
+1. Insert `_<ALT_PLAN_LANG_CODE>` before the `.md` suffix of `OUTPUT_FILE`.
+2. The variant file is placed in the same directory as `OUTPUT_FILE`.
+
+Examples:
+
+- `idea.md -> idea_zh.md`
+- `docs/my-idea.md -> docs/my-idea_zh.md`
+
+Variant content rules:
+
+1. Translate human-readable draft prose into `ALT_PLAN_LANGUAGE`; for Chinese, default to Simplified Chinese.
+2. Keep the original idea body byte-identical inside `## Original Idea`.
+3. Preserve identifiers, file paths, API names, command flags, direction IDs, and sentinels.
+4. Preserve the sentinel text exactly: `exploratory, no concrete precedent`.
+5. Do not add information that is absent from the canonical draft.
+6. `DIRECTIONS_JSON_FILE` is not translated, rewritten, or given a language variant.
+
+If `ALT_PLAN_LANGUAGE` is empty, do not create a translated draft variant.
+
+### Step 4.7: Report
 
 Report to the user:
 - Draft path written: `OUTPUT_FILE`
 - Companion JSON path written: `DIRECTIONS_JSON_FILE`
+- Translated draft variant path written (`DRAFT_VARIANT_FILE`) when enabled, otherwise note that the translated draft variant is disabled.
 - Primary direction name.
 - Requested `N` and the actual direction count (note if reduced due to degradation).
 - Next-step hints:
@@ -268,6 +365,7 @@ Report to the user:
 - Phase 1 validation errors stop the command with a clear message. No partial output.
 - Phase 2 degradation follows the retry-once + ≥2 minimum rule stated above.
 - Phase 3 degradation follows the drop-and-continue + ≥2 minimum rule stated above.
-- Never fabricate repo references or prior art. The `exploratory, no concrete precedent` sentinel from subagents is preserved verbatim in the draft.
-- If any phase stops with an error, do not write a partial `OUTPUT_FILE` or `DIRECTIONS_JSON_FILE`.
-- If companion JSON validation fails after writing both files, delete both files and stop.
+- Never fabricate repo references or prior art. The `exploratory, no concrete precedent` sentinel from subagents is preserved verbatim in the draft and any translated draft variant.
+- If the translated draft variant path already exists, stop before Phase 2 with no writes.
+- If any phase stops with an error, do not write partial `OUTPUT_FILE`, `DIRECTIONS_JSON_FILE`, or translated draft variant artifacts.
+- If companion JSON validation fails after writing both canonical files, delete both canonical files and stop; the translated draft variant MUST NOT have been written yet.

--- a/docs/usage.md
+++ b/docs/usage.md
@@ -72,7 +72,7 @@ The quiz is advisory, not a gate. You always have the option to proceed. But tha
 ### gen-idea
 
 ```
-/humanize:gen-idea <idea-text-or-path> [--n <int>] [--output <path>]
+/humanize:gen-idea <idea-text-or-path> [--n <int>] [--output <path>] [--alt-language <language-or-code>]
 ```
 
 Generates a repo-grounded idea draft using directed-diversity exploration. A lead agent picks N orthogonal directions, N parallel Explore subagents develop each direction with objective evidence from the repo, and the lead synthesizes a draft with one primary direction plus N-1 alternatives.
@@ -80,15 +80,17 @@ Generates a repo-grounded idea draft using directed-diversity exploration. A lea
 **Outputs:**
 - Draft file: `.humanize/ideas/<slug>-<timestamp>.md` (or `--output` path)
 - Companion JSON: `<draft-path-without-.md>.directions.json` — lossless record of all direction proposals, used as input to `explore-idea`
+- Optional translated draft variant: `_<code>` inserted before the draft file extension, written only when `--alt-language` or config enables a supported non-English language
 
 **Options:**
 - `--n <int>` — number of parallel directions (default: 6)
 - `--output <path>` — custom output path for the draft (must have `.md` suffix)
+- `--alt-language <language-or-code>` — generate a translated draft Markdown variant; supported values are zh, ko, ja, es, fr, de, pt, ru, ar or full language names; en/English is a no-op
 
 ### explore-idea
 
 ```
-/humanize:explore-idea <draft.md | draft.directions.json> [--directions ids] [--concurrency N] [--max-worker-iterations N] [--worker-timeout-min N] [--codex-timeout-min N]
+/humanize:explore-idea <draft.md | draft.directions.json> [--directions ids] [--concurrency N] [--max-worker-iterations N] [--worker-timeout-min N] [--codex-timeout-min N] [--alt-language <language-or-code>]
 ```
 
 Launches bounded parallel prototype workers — one per selected direction — each running in an isolated git worktree. After all workers complete, synthesizes an explore report plus a plan-ready final idea:
@@ -101,6 +103,7 @@ Launches bounded parallel prototype workers — one per selected direction — e
 - `--max-worker-iterations <N>` — per-worker iteration cap (default: 2, max: 3)
 - `--worker-timeout-min <N>` — worker timeout in minutes (default: 60, max: 60)
 - `--codex-timeout-min <N>` — Codex call timeout in minutes (default: 20, max: 20)
+- `--alt-language <language-or-code>` — generate a translated `final-idea.md` Markdown variant; supported values are zh, ko, ja, es, fr, de, pt, ru, ar or full language names; en/English is a no-op
 
 **Run artifacts** stored in `.humanize/explore/<RUN_ID>/`:
 - `manifest.json` — coordinator state and per-worker metadata
@@ -108,6 +111,7 @@ Launches bounded parallel prototype workers — one per selected direction — e
 - `worker-results.jsonl` — machine-readable result rows
 - `explore-report.md` — audit report with two-tier rankings, adoption paths, and cleanup guidance
 - `final-idea.md` — plan-ready synthesis artifact for `/humanize:gen-plan`
+- `final-idea_<code>.md` — optional translated plan-ready synthesis variant when alternative language output is enabled
 
 Default follow-up:
 ```bash
@@ -318,7 +322,7 @@ Current built-in keys:
 | `bitlesson_model` | `haiku` | Model used by the BitLesson selector agent |
 | `provider_mode` | unset | Optional runtime mode hint such as `codex-only` |
 | `agent_teams` | `false` | Project-level default for agent teams workflow |
-| `alternative_plan_language` | `""` | Optional translated plan variant language; supported values include `Chinese`, `Korean`, `Japanese`, `Spanish`, `French`, `German`, `Portuguese`, `Russian`, `Arabic`, or ISO codes like `zh` |
+| `alternative_plan_language` | `""` | Optional translated variant language for generated plan-ready Markdown artifacts, including gen-plan plans, refine-plan plan/QA outputs, gen-idea drafts, and explore-idea final ideas; supported values include `Chinese`, `Korean`, `Japanese`, `Spanish`, `French`, `German`, `Portuguese`, `Russian`, `Arabic`, or ISO codes like `zh` |
 | `gen_plan_mode` | `discussion` | Default plan-generation mode |
 
 ### Codex Model Configuration

--- a/tests/test-explore-command-structure.sh
+++ b/tests/test-explore-command-structure.sh
@@ -156,6 +156,59 @@ else
 fi
 
 echo ""
+echo "--- Alternative Language Variant ---"
+echo ""
+
+if grep -q -- "--alt-language <language-or-code>" "$EXPLORE_CMD"; then
+    pass "explore-idea.md exposes --alt-language option"
+else
+    fail "explore-idea.md exposes --alt-language option" "--alt-language <language-or-code>" "not found"
+fi
+
+if grep -q "alternative_plan_language" "$EXPLORE_CMD"; then
+    pass "explore-idea.md reads alternative_plan_language"
+else
+    fail "explore-idea.md reads alternative_plan_language" "alternative_plan_language" "not found"
+fi
+
+if grep -q "config-loader.sh" "$EXPLORE_CMD" && grep -q "load_merged_config" "$EXPLORE_CMD"; then
+    pass "explore-idea.md uses config-loader merge semantics"
+else
+    fail "explore-idea.md uses config-loader merge semantics" "config-loader.sh + load_merged_config" "missing"
+fi
+
+if grep -q "ALT_PLAN_LANGUAGE" "$EXPLORE_CMD" && grep -q "ALT_PLAN_LANG_CODE" "$EXPLORE_CMD"; then
+    pass "explore-idea.md defines ALT_PLAN_LANGUAGE and ALT_PLAN_LANG_CODE"
+else
+    fail "explore-idea.md defines alternative language variables" "ALT_PLAN_LANGUAGE + ALT_PLAN_LANG_CODE" "missing"
+fi
+
+if grep -q "final-idea.md -> final-idea_zh.md" "$EXPLORE_CMD"; then
+    pass "explore-idea.md documents final-idea.md -> final-idea_zh.md"
+else
+    fail "explore-idea.md documents final idea variant naming" "final-idea.md -> final-idea_zh.md" "missing"
+fi
+
+if grep -q 'explore-report.md` is not translated' "$EXPLORE_CMD" \
+        && grep -q 'worker-results.jsonl` is not translated' "$EXPLORE_CMD"; then
+    pass "explore-idea.md keeps report and worker results canonical"
+else
+    fail "explore-idea.md keeps report and worker results canonical" "explore-report.md and worker-results.jsonl are not translated" "missing"
+fi
+
+if grep -q "Final idea variant:" "$EXPLORE_CMD"; then
+    pass "explore-idea.md includes final idea variant confirmation line"
+else
+    fail "explore-idea.md includes final idea variant confirmation line" "Final idea variant:" "missing"
+fi
+
+if grep -q 'Keep `--alt-language` out of the validator invocation' "$EXPLORE_CMD"; then
+    pass "explore-idea.md strips --alt-language before validator invocation"
+else
+    fail "explore-idea.md strips --alt-language before validator invocation" "Keep --alt-language out of validator invocation" "missing"
+fi
+
+echo ""
 echo "--- Worker Dispatch Pattern ---"
 echo ""
 

--- a/tests/test-gen-idea-dual-write.sh
+++ b/tests/test-gen-idea-dual-write.sh
@@ -75,7 +75,79 @@ else
     fail "gen-idea.md lists validate-directions-json.sh in allowed-tools" "found in allowed-tools" "not found"
 fi
 
-# PT-5: validate-directions-json.sh validates the valid fixture
+# PT-5: gen-idea.md exposes alternative language option
+if grep -q -- "--alt-language <language-or-code>" "$GEN_IDEA_CMD"; then
+    pass "gen-idea.md exposes --alt-language option"
+else
+    fail "gen-idea.md exposes --alt-language option" "--alt-language <language-or-code>" "not found"
+fi
+
+# PT-6: gen-idea.md reads alternative_plan_language from merged config
+if grep -q "alternative_plan_language" "$GEN_IDEA_CMD"; then
+    pass "gen-idea.md reads alternative_plan_language"
+else
+    fail "gen-idea.md reads alternative_plan_language" "alternative_plan_language" "not found"
+fi
+
+# PT-7: gen-idea.md reuses config-loader merge semantics
+if grep -q "config-loader.sh" "$GEN_IDEA_CMD" && grep -q "load_merged_config" "$GEN_IDEA_CMD"; then
+    pass "gen-idea.md uses config-loader merge semantics"
+else
+    fail "gen-idea.md uses config-loader merge semantics" "config-loader.sh + load_merged_config" "missing"
+fi
+
+# PT-8: gen-idea.md defines normalized alt language variables
+if grep -q "ALT_PLAN_LANGUAGE" "$GEN_IDEA_CMD" && grep -q "ALT_PLAN_LANG_CODE" "$GEN_IDEA_CMD"; then
+    pass "gen-idea.md defines ALT_PLAN_LANGUAGE and ALT_PLAN_LANG_CODE"
+else
+    fail "gen-idea.md defines alternative language variables" "ALT_PLAN_LANGUAGE + ALT_PLAN_LANG_CODE" "missing"
+fi
+
+# PT-9: gen-idea.md documents draft variant naming
+if grep -q "idea.md -> idea_zh.md" "$GEN_IDEA_CMD"; then
+    pass "gen-idea.md documents idea.md -> idea_zh.md"
+else
+    fail "gen-idea.md documents draft variant naming" "idea.md -> idea_zh.md" "missing"
+fi
+
+# PT-10: gen-idea.md keeps directions JSON canonical
+if grep -q 'DIRECTIONS_JSON_FILE` is not translated' "$GEN_IDEA_CMD"; then
+    pass "gen-idea.md states DIRECTIONS_JSON_FILE is not translated"
+else
+    fail "gen-idea.md states directions JSON is not translated" "DIRECTIONS_JSON_FILE is not translated" "missing"
+fi
+
+# PT-11: gen-idea.md strips --alt-language before validator invocation
+if grep -q 'Keep `--alt-language` out of the validator invocation' "$GEN_IDEA_CMD"; then
+    pass "gen-idea.md strips --alt-language before validator invocation"
+else
+    fail "gen-idea.md strips --alt-language before validator invocation" "Keep --alt-language out of validator invocation" "missing"
+fi
+
+# PT-12: gen-idea.md keeps warning path on config-loading flow
+if grep -q 'Surface these warnings.*continue Phase 1\.5' "$GEN_IDEA_CMD"; then
+    pass "gen-idea.md warning path continues to Phase 1.5"
+else
+    fail "gen-idea.md warning path continues to Phase 1.5" "continue Phase 1.5" "missing"
+fi
+
+# PT-13: gen-idea.md preflights translated draft variant collision before writes
+if grep -q "DRAFT_VARIANT_FILE" "$GEN_IDEA_CMD" \
+        && grep -q "Translated draft variant already exists" "$GEN_IDEA_CMD" \
+        && grep -q "before any canonical outputs are written" "$GEN_IDEA_CMD"; then
+    pass "gen-idea.md preflights translated draft variant collision"
+else
+    fail "gen-idea.md preflights translated draft variant collision" "DRAFT_VARIANT_FILE collision check before canonical writes" "missing"
+fi
+
+# PT-14: gen-idea.md does not document impossible extensionless variant output
+if grep -q "output -> output_zh" "$GEN_IDEA_CMD"; then
+    fail "gen-idea.md omits extensionless variant example" "no output -> output_zh example" "found"
+else
+    pass "gen-idea.md omits extensionless variant example"
+fi
+
+# PT-15: validate-directions-json.sh validates the valid fixture
 if command -v jq &>/dev/null; then
     VALID_FIXTURE="$SCRIPT_DIR/fixtures/directions/valid.directions.json"
     EXIT_CODE=0


### PR DESCRIPTION
  ## Summary
  - add `--alt-language` handling and `alternative_plan_language` config support to `gen-idea` draft output
  - add translated final idea variant support to `explore-idea` while keeping report and machine-readable artifacts canonical
  - document the expanded config behavior and add structural regression coverage

  Closes #182

  ## Tests
  - `bash tests/test-gen-idea-dual-write.sh`
  - `bash tests/test-explore-command-structure.sh`
  - `bash tests/run-all-tests.sh` 