### PR TITLE
Support Codex hooks feature rename and prevent nested Stop hook recursion

### DIFF
--- a/docs/install-for-codex.md
+++ b/docs/install-for-codex.md
@@ -26,7 +26,7 @@ This will:
 - Sync `humanize`, `humanize-gen-plan`, `humanize-refine-plan`, and `humanize-rlcr` into `${CODEX_HOME:-~/.codex}/skills`
 - Copy runtime dependencies into `${CODEX_HOME:-~/.codex}/skills/humanize`
 - Install/update native Humanize Stop hooks in `${CODEX_HOME:-~/.codex}/hooks.json`
-- Enable the experimental `codex_hooks` feature in `${CODEX_HOME:-~/.codex}/config.toml` when `codex` is available
+- Enable the Codex native hooks feature in `${CODEX_HOME:-~/.codex}/config.toml` when `codex` is available (`hooks` on current Codex builds, `codex_hooks` on older supported builds)
 - Seed `~/.config/humanize/config.json` with a Codex/OpenAI `bitlesson_model` when that key is not already set
 - Mark the install as `provider_mode: "codex-only"` when using `--target codex`
 - Use RLCR defaults: `codex exec` with `gpt-5.5:high`, `codex review` with `gpt-5.5:high`
@@ -70,12 +70,12 @@ Installed files/directories:
 Verify native hooks:
 
 ```bash
-codex features list | rg codex_hooks
+codex features list | rg '^(hooks|codex_hooks)\s'
 sed -n '1,220p' "${CODEX_HOME:-$HOME/.codex}/hooks.json"
 ```
 
 Expected:
-- `codex_hooks` is `true`
+- `hooks` or `codex_hooks` is `true`
 - `hooks.json` contains `loop-codex-stop-hook.sh`
 - `${XDG_CONFIG_HOME:-~/.config}/humanize/config.json` contains `bitlesson_model` set to a Codex/OpenAI model such as `gpt-5.5`
 - for `--target codex`, `${XDG_CONFIG_HOME:-~/.config}/humanize/config.json` also contains `provider_mode: "codex-only"`
@@ -110,6 +110,6 @@ ls -la "${CODEX_HOME:-$HOME/.codex}/skills/humanize/scripts"
 If native exit gating does not trigger:
 
 ```bash
-codex features enable codex_hooks
+codex features enable hooks
 sed -n '1,220p' "${CODEX_HOME:-$HOME/.codex}/hooks.json"
 ```

--- a/hooks/loop-codex-stop-hook.sh
+++ b/hooks/loop-codex-stop-hook.sh
@@ -1167,17 +1167,32 @@ mkdir -p "$CACHE_DIR"
 # portable-timeout.sh already sourced above
 
 # Disable native hooks for nested Codex reviewer calls to prevent Stop-hook recursion.
-# Probe whether the installed Codex CLI supports --disable; cache the result per loop
-# so older builds do not fail with an unknown-argument error.
+# Newer Codex builds expose the feature as "hooks"; older builds used
+# "codex_hooks". Cache the detected feature name per loop.
 CODEX_DISABLE_HOOKS_ARGS=()
-_CODEX_FEATURE_CACHE="$CACHE_DIR/.codex-disable-hooks-supported"
+_CODEX_FEATURE_CACHE="$CACHE_DIR/.codex-disable-hooks-feature"
 if [[ -f "$_CODEX_FEATURE_CACHE" ]]; then
-    [[ "$(cat "$_CODEX_FEATURE_CACHE")" == "yes" ]] && CODEX_DISABLE_HOOKS_ARGS=(--disable codex_hooks)
-elif codex --help 2>&1 | grep -q -- '--disable'; then
-    CODEX_DISABLE_HOOKS_ARGS=(--disable codex_hooks)
-    echo "yes" > "$_CODEX_FEATURE_CACHE" 2>/dev/null
-else
-    echo "no" > "$_CODEX_FEATURE_CACHE" 2>/dev/null
+    _CODEX_DISABLE_HOOKS_FEATURE="$(cat "$_CODEX_FEATURE_CACHE")"
+    if [[ "$_CODEX_DISABLE_HOOKS_FEATURE" == "hooks" || "$_CODEX_DISABLE_HOOKS_FEATURE" == "codex_hooks" ]]; then
+        CODEX_DISABLE_HOOKS_ARGS=(--disable "$_CODEX_DISABLE_HOOKS_FEATURE")
+    fi
+fi
+if [[ ${#CODEX_DISABLE_HOOKS_ARGS[@]} -eq 0 ]]; then
+    _CODEX_HELP_TEXT="$(codex --help 2>&1 || true)"
+    if grep -q -- '--disable' <<< "$_CODEX_HELP_TEXT"; then
+        _CODEX_FEATURE_LIST="$(codex features list 2>/dev/null || true)"
+        if grep -qE '^hooks[[:space:]]' <<< "$_CODEX_FEATURE_LIST"; then
+            _CODEX_DISABLE_HOOKS_FEATURE="hooks"
+        elif grep -qE '^codex_hooks[[:space:]]' <<< "$_CODEX_FEATURE_LIST"; then
+            _CODEX_DISABLE_HOOKS_FEATURE="codex_hooks"
+        else
+            _CODEX_DISABLE_HOOKS_FEATURE="codex_hooks"
+        fi
+        CODEX_DISABLE_HOOKS_ARGS=(--disable "$_CODEX_DISABLE_HOOKS_FEATURE")
+        echo "$_CODEX_DISABLE_HOOKS_FEATURE" > "$_CODEX_FEATURE_CACHE" 2>/dev/null
+    else
+        : > "$_CODEX_FEATURE_CACHE" 2>/dev/null
+    fi
 fi
 
 # Build command arguments for summary review (codex exec)

--- a/scripts/bitlesson-select.sh
+++ b/scripts/bitlesson-select.sh
@@ -191,15 +191,28 @@ run_selector() {
 
     if [[ "$provider" == "codex" ]]; then
         local codex_exec_args=()
-        # Probe whether the installed Codex CLI supports --disable flag
-        if codex --help 2>&1 | grep -q -- '--disable'; then
-            codex_exec_args+=("--disable" "codex_hooks")
+        local codex_help_text=""
+        local codex_exec_help_text=""
+        # Probe whether the installed Codex CLI supports --disable, then disable
+        # the active native hooks feature for this helper Codex invocation.
+        codex_help_text="$(codex --help 2>&1 || true)"
+        if grep -q -- '--disable' <<< "$codex_help_text"; then
+            local feature_list=""
+            feature_list="$(codex features list 2>/dev/null || true)"
+            if grep -qE '^hooks[[:space:]]' <<< "$feature_list"; then
+                codex_exec_args+=("--disable" "hooks")
+            elif grep -qE '^codex_hooks[[:space:]]' <<< "$feature_list"; then
+                codex_exec_args+=("--disable" "codex_hooks")
+            else
+                codex_exec_args+=("--disable" "codex_hooks")
+            fi
         fi
         # Probe for --skip-git-repo-check and --ephemeral support
-        if codex exec --help 2>&1 | grep -q -- '--skip-git-repo-check'; then
+        codex_exec_help_text="$(codex exec --help 2>&1 || true)"
+        if grep -q -- '--skip-git-repo-check' <<< "$codex_exec_help_text"; then
             codex_exec_args+=("--skip-git-repo-check")
         fi
-        if codex exec --help 2>&1 | grep -q -- '--ephemeral'; then
+        if grep -q -- '--ephemeral' <<< "$codex_exec_help_text"; then
             codex_exec_args+=("--ephemeral")
         fi
         codex_exec_args+=(

--- a/scripts/install-codex-hooks.sh
+++ b/scripts/install-codex-hooks.sh
@@ -23,7 +23,7 @@ Usage:
 Options:
   --codex-config-dir PATH  Codex config dir (default: ${CODEX_HOME:-~/.codex})
   --runtime-root PATH      Installed Humanize runtime root (default: <codex-config-dir>/skills/humanize)
-  --skip-enable-feature    Do not run `codex features enable codex_hooks`
+  --skip-enable-feature    Do not run `codex features enable <hooks-feature>`
   --dry-run                Print actions without writing
   -h, --help               Show help
 EOF
@@ -71,14 +71,32 @@ done
 [[ -f "$HOOKS_TEMPLATE" ]] || die "hook template not found: $HOOKS_TEMPLATE"
 
 HOOKS_FILE="$CODEX_CONFIG_DIR/hooks.json"
+CODEX_HOOKS_FEATURE=""
 
-require_codex_hooks_support() {
+detect_codex_hooks_feature() {
     if ! command -v codex >/dev/null 2>&1; then
         die "Codex CLI with native hooks support is required. Install Codex 0.114.0+ first."
     fi
 
-    if ! codex features list 2>/dev/null | grep -qE '^codex_hooks[[:space:]]'; then
-        die "Installed Codex CLI does not expose the codex_hooks feature. Humanize Codex install requires Codex 0.114.0+."
+    local features
+    features="$(codex features list 2>/dev/null)" || return 1
+
+    if grep -qE '^hooks[[:space:]]' <<< "$features"; then
+        CODEX_HOOKS_FEATURE="hooks"
+        return 0
+    fi
+
+    if grep -qE '^codex_hooks[[:space:]]' <<< "$features"; then
+        CODEX_HOOKS_FEATURE="codex_hooks"
+        return 0
+    fi
+
+    return 1
+}
+
+require_codex_hooks_support() {
+    if ! detect_codex_hooks_feature; then
+        die "Installed Codex CLI does not expose the hooks/codex_hooks feature. Humanize Codex install requires native hooks support."
     fi
 }
 
@@ -177,10 +195,12 @@ enable_feature() {
 
     [[ "$ENABLE_FEATURE" == "true" ]] || return 0
 
-    if CODEX_HOME="$config_dir" codex features enable codex_hooks >/dev/null 2>&1; then
-        log "enabled codex_hooks feature in $config_dir/config.toml"
+    [[ -n "$CODEX_HOOKS_FEATURE" ]] || detect_codex_hooks_feature || die "could not determine Codex hooks feature name"
+    local feature="$CODEX_HOOKS_FEATURE"
+    if CODEX_HOME="$config_dir" codex features enable "$feature" >/dev/null 2>&1; then
+        log "enabled $feature feature in $config_dir/config.toml"
     else
-        die "failed to enable codex_hooks feature automatically in $config_dir/config.toml"
+        die "failed to enable $feature feature automatically in $config_dir/config.toml"
     fi
 }
 
@@ -193,7 +213,7 @@ require_codex_hooks_support
 if [[ "$DRY_RUN" == "true" ]]; then
     log "DRY-RUN merge $HOOKS_TEMPLATE -> $HOOKS_FILE"
     if [[ "$ENABLE_FEATURE" == "true" ]]; then
-        log "DRY-RUN enable codex_hooks feature in $CODEX_CONFIG_DIR/config.toml"
+        log "DRY-RUN enable $CODEX_HOOKS_FEATURE feature in $CODEX_CONFIG_DIR/config.toml"
     fi
     exit 0
 fi

--- a/skills/humanize/SKILL.md
+++ b/skills/humanize/SKILL.md
@@ -45,7 +45,7 @@ The RLCR (Ralph-Loop with Codex Review) loop has two phases:
 - Issues marked with `[P0-9]` severity markers
 - If issues found → AI fixes them and continues
 - If no issues → loop completes with Finalize Phase
-- On Codex CLI `0.114.0+` with `codex_hooks` enabled, Humanize installs a native `Stop` hook so exit gating runs automatically
+- On Codex CLI `0.114.0+` with native hooks enabled (`hooks` on current builds, `codex_hooks` on older builds), Humanize installs a native `Stop` hook so exit gating runs automatically
 
 ### 2. Generate Plan - Structured Plan from Draft
 

--- a/tests/test-bitlesson-select-routing.sh
+++ b/tests/test-bitlesson-select-routing.sh
@@ -449,6 +449,11 @@ mkdir -p "$CAPTURE_BIN"
 cat > "$CAPTURE_BIN/codex" <<'EOF'
 #!/usr/bin/env bash
 # Respond to help probes with supported flags
+if [[ "${1:-}" == "features" && "${2:-}" == "list" ]]; then
+    echo "hooks                            stable             true"
+    exit 0
+fi
+
 for arg in "$@"; do
     if [[ "$arg" == "--help" ]]; then
         echo "  --disable <feature>   Disable a feature"
@@ -481,7 +486,7 @@ captured_args="$(cat "$CAPTURE_ARGS")"
 if [[ $exit_code -eq 0 ]] \
     && echo "$stdout_out" | grep -q "BL-20260315-tracker-drift" \
     && echo "$captured_args" | grep -q -- '--disable' \
-    && echo "$captured_args" | grep -q -- 'codex_hooks' \
+    && echo "$captured_args" | grep -q -- 'hooks' \
     && echo "$captured_args" | grep -q -- '--skip-git-repo-check' \
     && echo "$captured_args" | grep -q -- '--ephemeral' \
     && echo "$captured_args" | grep -q -- 'read-only' \

--- a/tests/test-codex-hook-install.sh
+++ b/tests/test-codex-hook-install.sh
@@ -43,12 +43,12 @@ set -euo pipefail
 
 if [[ "${1:-}" == "features" && "${2:-}" == "list" ]]; then
     cat <<'LIST'
-codex_hooks                      under development  false
+hooks                            stable             false
 LIST
     exit 0
 fi
 
-if [[ "${1:-}" == "features" && "${2:-}" == "enable" && "${3:-}" == "codex_hooks" ]]; then
+if [[ "${1:-}" == "features" && "${2:-}" == "enable" && "${3:-}" == "hooks" ]]; then
     printf 'CODEX_HOME=%s\n' "${CODEX_HOME:-}" >> "${TEST_CODEX_FEATURE_LOG:?}"
     mkdir -p "${CODEX_HOME:?}"
     : > "${CODEX_HOME}/.codex-hooks-enabled"
@@ -134,9 +134,9 @@ else
 fi
 
 if [[ -f "$CODEX_HOME_DIR/.codex-hooks-enabled" ]]; then
-    pass "Codex install enables codex_hooks feature"
+    pass "Codex install enables hooks feature"
 else
-    fail "Codex install enables codex_hooks feature" ".codex-hooks-enabled marker exists" "missing"
+    fail "Codex install enables hooks feature" ".codex-hooks-enabled marker exists" "missing"
 fi
 
 if [[ -f "$HUMANIZE_USER_CONFIG" ]]; then
@@ -323,11 +323,11 @@ else
     fail "Codex install rejects builds without native hooks support" "non-zero exit" "exit 0"
 fi
 
-if grep -q "codex_hooks feature" "$TEST_DIR/install-unsupported.log"; then
-    pass "Unsupported Codex failure explains missing codex_hooks feature"
+if grep -q "hooks/codex_hooks feature" "$TEST_DIR/install-unsupported.log"; then
+    pass "Unsupported Codex failure explains missing hooks/codex_hooks feature"
 else
-    fail "Unsupported Codex failure explains missing codex_hooks feature" \
-        "error mentioning codex_hooks feature" \
+    fail "Unsupported Codex failure explains missing hooks/codex_hooks feature" \
+        "error mentioning hooks/codex_hooks feature" \
         "$(cat "$TEST_DIR/install-unsupported.log")"
 fi
 

--- a/tests/test-disable-nested-codex-hooks.sh
+++ b/tests/test-disable-nested-codex-hooks.sh
@@ -77,9 +77,14 @@ if [[ "\$1" == "--help" ]]; then
 Usage: codex [OPTIONS] <COMMAND>
 
 Options:
-  --disable <HOOK>         Disable a specific Codex hook (e.g. codex_hooks)
+  --disable <HOOK>         Disable a specific Codex hook (e.g. hooks)
   --skip-git-repo-check    Skip git repo validation
 HELP
+    exit 0
+fi
+
+if [[ "\$1" == "features" && "\$2" == "list" ]]; then
+    echo "hooks                            stable             true"
     exit 0
 fi
 
@@ -188,22 +193,22 @@ REPO_IMPL="$TEST_DIR/repo-impl"
 setup_repo "$REPO_IMPL"
 run_loop_hook "$REPO_IMPL" "$TEST_DIR/impl.args" "false"
 
-if grep -q -- 'exec --disable codex_hooks' "$TEST_DIR/impl.args"; then
-    pass "implementation-phase stop hook disables codex_hooks for codex exec"
+if grep -q -- 'exec --disable hooks' "$TEST_DIR/impl.args"; then
+    pass "implementation-phase stop hook disables hooks for codex exec"
 else
-    fail "implementation-phase stop hook disables codex_hooks for codex exec" \
-        "exec --disable codex_hooks" "$(cat "$TEST_DIR/impl.args" 2>/dev/null || echo missing)"
+    fail "implementation-phase stop hook disables hooks for codex exec" \
+        "exec --disable hooks" "$(cat "$TEST_DIR/impl.args" 2>/dev/null || echo missing)"
 fi
 
 REPO_REVIEW="$TEST_DIR/repo-review"
 setup_repo "$REPO_REVIEW"
 run_loop_hook "$REPO_REVIEW" "$TEST_DIR/review.args" "true"
 
-if grep -q -- 'review --disable codex_hooks' "$TEST_DIR/review.args"; then
-    pass "review-phase stop hook disables codex_hooks for codex review"
+if grep -q -- 'review --disable hooks' "$TEST_DIR/review.args"; then
+    pass "review-phase stop hook disables hooks for codex review"
 else
-    fail "review-phase stop hook disables codex_hooks for codex review" \
-        "review --disable codex_hooks" "$(cat "$TEST_DIR/review.args" 2>/dev/null || echo missing)"
+    fail "review-phase stop hook disables hooks for codex review" \
+        "review --disable hooks" "$(cat "$TEST_DIR/review.args" 2>/dev/null || echo missing)"
 fi
 
 echo ""


### PR DESCRIPTION
## Summary

This updates the Codex integration to support the current native hooks feature name, `hooks`, while retaining compatibility with older Codex builds that expose `codex_hooks`.

The main behavioral fix is that nested Codex reviewer/helper invocations now disable the active hooks feature. This prevents Humanize's Codex Stop hook from recursively triggering itself when it launches `codex review` or `codex exec`.

## Problem

Current Codex builds expose lifecycle hooks as the stable `hooks` feature:

```text
hooks                                   stable             true
```

Codex docs also describe `hooks` as the canonical feature key and `codex_hooks` as a deprecated alias.

Humanize still assumed `codex_hooks` in several Codex paths:

- install-time feature detection
- install-time feature enablement
- nested Stop-hook `codex review` / `codex exec` calls
- BitLesson helper `codex exec` calls

That creates two failure modes on current Codex builds:

1. Installation can reject a Codex CLI that supports native hooks because the script only searches for `codex_hooks`.
2. Nested Codex calls may use `--disable codex_hooks` even though the active feature is `hooks`. In that case, Stop hooks are not disabled for the nested Codex process, so the nested reviewer/helper can trigger the same Stop hook again when it exits.

## Root Cause

The feature was renamed from the older `codex_hooks` key to the canonical `hooks` key. The install/runtime scripts did not consistently detect which feature name the installed Codex CLI exposes, and some paths hard-coded `codex_hooks`.

There was also a related shell robustness issue: several probes used `command | grep -q` under `set -o pipefail`. When `grep -q` exits early after finding a match, the producer can receive `SIGPIPE`, causing the whole pipeline to look like a failed probe. This can make supported Codex flags/features appear unsupported.

## Changes

- Detect `hooks` first and fall back to `codex_hooks` when installing Codex hooks.
- Enable the detected hooks feature instead of always enabling `codex_hooks`.
- Disable the detected hooks feature for nested Stop hook `codex review` and `codex exec` calls.
- Disable the detected hooks feature for BitLesson helper Codex calls.
- Cache the detected nested-disable feature name per loop instead of caching only a yes/no value.
- Avoid `grep -q` in `pipefail` pipelines for Codex feature/help probes by capturing command output first.
- Update Codex install docs and Humanize skill docs to mention current and legacy feature names.
- Update tests to simulate current Codex `hooks` output and assert nested calls use `--disable hooks`.

## Compatibility

This keeps older Codex compatibility by falling back to `codex_hooks` when `hooks` is not present in `codex features list`.

## Validation

- `bash -n scripts/install-codex-hooks.sh hooks/loop-codex-stop-hook.sh scripts/bitlesson-select.sh tests/test-codex-hook-install.sh tests/test-disable-nested-codex-hooks.sh tests/test-bitlesson-select-routing.sh`
- `bash tests/test-codex-hook-install.sh`
- `bash tests/test-disable-nested-codex-hooks.sh`
- `bash tests/test-bitlesson-select-routing.sh`
